### PR TITLE
Add velum configuration settings

### DIFF
--- a/salt.yaml
+++ b/salt.yaml
@@ -52,22 +52,22 @@ spec:
   volumes:
     - name: salt-master-config
       hostPath:
-        path: $TODO_PREFIX/config/salt/master.d # FIXME: prefix for this package (config folder)
+        path: /usr/share/caasp-container-manifests/config/salt/master.d
     - name: salt-master
       hostPath:
-        path: $TODO_SALT_STATES # FIXME: where are salt states installed in microos?
+        path: /usr/share/salt/kubernetes/salt
     - name: salt-pillar
       hostPath:
-        path: $TODO_SALT_PILLAR # FIXME: where is salt pillar installed in microos?
+        path: /usr/share/salt/kubernetes/pillar
     - name: salt-sock-dir
       hostPath:
-        path: $TODO_SALT_MASTER_SOCK_DIR # FIXME: where is the salt master sock dir located in microos?
+        path: /var/run/salt/master/sock-dir
     - name: salt-minion-ca-grains
       hostPath:
-        path: $TODO_PREFIX/config/salt/grains/ca # FIXME: prefix for this package (config folder)
+        path: /usr/share/caasp-container-manifests/config/salt/grains/ca
     - name: salt-minion-ca-config
       hostPath:
-        path: $TODO_PREFIX/config/salt/minion.d-ca/minion.conf # FIXME: prefix for this package (config folder)
+        path: /usr/share/caasp-container-manifests/config/salt/minion.d-ca/minion.conf
     - name: salt-minion-ca-signing-policies
       hostPath:
-        path: $TODO_PREFIX/config/salt/minion.d-ca/signing_policies.conf # FIXME: prefix for this package (config folder)
+        path: /usr/share/caasp-container-manifests/config/salt/minion.d-ca/signing_policies.conf

--- a/velum.yaml
+++ b/velum.yaml
@@ -32,7 +32,7 @@ spec:
     - name: VELUM_DB_PORT
       value: "3306"
     - name: VELUM_DB_USERNAME
-      value: "root" # FIXME: do not use root user
+      value: "root"
     - name: VELUM_DB_PASSWORD
       value: "salt"
     - name: VELUM_SALT_HOST
@@ -40,9 +40,9 @@ spec:
     - name: VELUM_SALT_PORT
       value: "8000"
     - name: VELUM_SALT_USER
-      value: saltapi # FIXME? -> https://github.com/openSUSE/docker-containers/blob/master/derived_images/salt/salt-master/Dockerfile#L9
+      value: saltapi
     - name: VELUM_SALT_PASSWORD
-      value: saltapi # FIXME? -> https://github.com/openSUSE/docker-containers/blob/master/derived_images/salt/salt-master/Dockerfile#L9
+      value: saltapi
     command: ["/bin/sh","-c"]
     args: ["bundle exec rails s -b 0.0.0.0 -p 3000 --pid /tmp/puma.pid Puma"]
   - name: velum-event-processor
@@ -59,22 +59,24 @@ spec:
     - name: VELUM_DB_PORT
       value: "3306"
     - name: VELUM_DB_USERNAME
-      value: "root" # FIXME: do not use root user
+      value: "root"
     - name: VELUM_DB_PASSWORD
       value: "salt"
     - name: VELUM_SALT_HOST
-      value:
+      value: "127.0.0.1"
     - name: VELUM_SALT_PORT
-      value:
+      value: "8000"
     - name: VELUM_SALT_USER
-      value:
+      value: saltapi
     command: ["/bin/sh","-c"]
     args: ["bundle exec bin/rake salt:process"]
-  - name: velum-mariadb # FIXME: being on the same pod (with hostNetwork: true) also exposes mysql (if it listens on 0.0.0.0).
+  - name: velum-mariadb
     image: sles12/mariadb:10.0
     env:
-    - name: MYSQL_ROOT_PASSWORD # FIXME: do not set root password, create user/password
-      value: "salt"             # FIXME
+    - name: MYSQL_ROOT_PASSWORD # Should match VELUM_DB_PASSWORD above
+      value: "salt"
+    - name: MYSQL_DISABLE_REMOTE_ROOT
+      value: "false"
     volumeMounts:
       - mountPath: /var/lib/mysql
         name: velum-mariadb-data


### PR DESCRIPTION
Some settings needs to be mounted from the filesystem, so we can generate this settings for each installation.

Instead of using environment variables, generate `secrets.yml` and `database.yml` files that will be mounted with some generated content for each installation.

This way we don't need to modify manifests (we cannot do it anyway).

There are still some things to adapt.