### PR TITLE
Give mariadb container persistent storage mapped to host /var/lib/mysql

### DIFF
--- a/velum.yaml
+++ b/velum.yaml
@@ -79,6 +79,7 @@ spec:
       - mountPath: /var/lib/mysql
         name: velum-mariadb-data
   volumes:
+    # Assume that database container sticks to the host that started it the very first time.
     - name: velum-mariadb-data
       hostPath:
         path: /var/lib/mysql

--- a/velum.yaml
+++ b/velum.yaml
@@ -75,3 +75,10 @@ spec:
     env:
     - name: MYSQL_ROOT_PASSWORD # FIXME: do not set root password, create user/password
       value: "salt"             # FIXME
+    volumeMounts:
+      - mountPath: /var/lib/mysql
+        name: velum-mariadb-data
+  volumes:
+    - name: velum-mariadb-data
+      hostPath:
+        path: /var/lib/mysql


### PR DESCRIPTION
ReadOnlyOS image 19.2 is the first revision to have the /var/lib/mysql subvolume.

Previous PR was accidentally closed via a forced git push:
https://github.com/kubic-project/caasp-container-manifests/pull/7