### PR TITLE
fix enabled services in controller node

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -22,4 +22,11 @@ fi
 cp -v $manifest_dir/salt.yaml $kube_dir
 cp -v $manifest_dir/velum.yaml $kube_dir
 
+# enable specific services to ControllerNode
+systemctl enable docker
+systemctl enable kubelet
+
+# disable services that should not be running in ControllerNode
+systemctl disable salt-minion
+
 


### PR DESCRIPTION
docker and kubelet are services that should be running in the controller
node. However they are disabled by default because they are not meant to
be running in the "worker" nodes.

salt-minion is the opposite case. salt-minion should be running in all
nodes except in the controller node, thus we should disable it.