### PR TITLE
Use port 80 by default

### DIFF
--- a/velum.yaml
+++ b/velum.yaml
@@ -44,7 +44,7 @@ spec:
     - name: VELUM_SALT_PASSWORD
       value: saltapi # FIXME? -> https://github.com/openSUSE/docker-containers/blob/master/derived_images/salt/salt-master/Dockerfile#L9
     command: ["/bin/sh","-c"]
-    args: ["bundle exec rails s -b 0.0.0.0 -p 3000 --pid /tmp/puma.pid Puma"]
+    args: ["bundle exec rails s -b 0.0.0.0 -p 80 --pid /tmp/puma.pid Puma"]
   - name: velum-event-processor
     image: sles12/velum:0.0
     env:


### PR DESCRIPTION
Use port 80 by default for velum service until we can actually use
port 443 to serve this content.