### PR TITLE
Skip copies when the manifests already exist there

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -1,26 +1,40 @@
 #!/bin/sh
+
 kube_dir=/etc/kubernetes/manifests
 manifest_dir=/usr/share/caasp-container-manifests
-if [ ! -d $kube_dir ]; then
-    echo "$kube_dir does not exist" >&2
-    echo "make sure kubernetes is installed" >&2
-    exit -1
-fi
-if [ ! -d $manifest_dir ]; then
-    echo "$manifest_dir does not exist" >&2
-    echo "manifest files are expected to be there" >&2
-    exit -2
-fi
-if [ ! -f $manifest_dir/salt.yaml ]; then
-    echo "salt.yaml is not in $manifest_dir" >&2
-    exit -3
-fi
-if [ ! -f $manifest_dir/velum.yaml ]; then
-    echo "velum.yaml is not in $manifest_dir" >&2
-    exit -3
-fi
-cp -v $manifest_dir/salt.yaml $kube_dir
-cp -v $manifest_dir/velum.yaml $kube_dir
+overwrite=1
+
+while [ $# -gt 0 ] ; do
+  case $1 in
+    --kube-dir)
+      kube_dir="$2"
+      shift
+      ;;
+    --manifests-dir)
+      manifest_dir="$2"
+      shift
+      ;;
+    --do-not-overwrite)
+      overwrite=
+      ;;
+    *)
+      abort "Unknown argument $1"
+      ;;
+  esac
+  shift
+done
+
+#########################################################
+
+mkdir -p $kube_dir
+for i in $manifest_dir/*.yaml ; do
+    echo "Copying $(basename $i) to $kube_dir"
+    if [ -f "$kube_dir/$(basename $i)" ] ; then
+        [ -n "$overwrite" ] && cp "$i" "$kube_dir/" || echo "... skipped"
+    else
+        cp "$i" "$kube_dir/"
+    fi
+done
 
 # Make sure that the controller node looks for the local pause image
 # TODO: remove this as soon as possible. As an idea, we could use a systemd drop-in unit.
@@ -30,6 +44,7 @@ sed -i 's|--config=/etc/kubernetes/manifests|--config=/etc/kubernetes/manifests 
 sed -i 's@#\?ETCD_LISTEN_PEER_URLS.*@ETCD_LISTEN_PEER_URLS=http://0.0.0.0:2380@' /etc/sysconfig/etcd
 sed -i 's@#\?ETCD_LISTEN_CLIENT_URLS.*@ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379@' /etc/sysconfig/etcd
 
+# TODO: these services should have been enabled by default
 if [ "$YAST_IS_RUNNING" = instsys ]; then
     # YaST is configuring controller node
     # enable specific services to ControllerNode


### PR DESCRIPTION
We already have _development versions_ of the manifest files at `/etc/kubernetes/manifests` when using Terraforrm, so we should skip the copies performed by `activate.sh`. Once we have this merged, we will be able to run `activate.sh` from `provision-dashboard.sh`