### PR TITLE
activate.sh: fix bsc#1032651

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -29,17 +29,3 @@ sed -i 's|--config=/etc/kubernetes/manifests|--config=/etc/kubernetes/manifests 
 # Make sure etcd listens on 0.0.0.0
 sed -i 's@#\?ETCD_LISTEN_PEER_URLS.*@ETCD_LISTEN_PEER_URLS=http://0.0.0.0:2380@' /etc/sysconfig/etcd
 sed -i 's@#\?ETCD_LISTEN_CLIENT_URLS.*@ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379@' /etc/sysconfig/etcd
-
-if [ "$YAST_IS_RUNNING" = instsys ]; then
-    # YaST is configuring controller node
-    # enable specific services to ControllerNode
-    systemctl enable docker
-    systemctl enable kubelet
-    systemctl enable etcd
-else
-    # cloud-init is configuring controller node
-    # enable and start specific services to ControllerNode
-    systemctl enable --now docker
-    systemctl enable --now kubelet
-    systemctl enable --now etcd
-fi


### PR DESCRIPTION
docker, kubelet and etcd on the administration node are now enabled by
the system role, we don't need to do that anymore in the activate.sh
script.

https://bugzilla.suse.com/show_bug.cgi?id=1032651

Signed-off-by: Maximilian Meister <mmeister@suse.de>