### PR TITLE
Replace the mount points for Salt code and pillar

### DIFF
--- a/config/salt/master.d/salt-master.conf
+++ b/config/salt/master.d/salt-master.conf
@@ -1,8 +1,8 @@
 user: root
 auto_accept: True
 interface: 0.0.0.0
-
 event_return: mysql
+presence_events: True
 
 file_roots:
   base:

--- a/config/salt/master.d/salt-master.conf
+++ b/config/salt/master.d/salt-master.conf
@@ -4,6 +4,14 @@ interface: 0.0.0.0
 
 event_return: mysql
 
+file_roots:
+  base:
+    - /usr/share/salt/kubernetes/salt
+
+pillar_roots:
+  base:
+    - /usr/share/salt/kubernetes/pillar
+
 mysql:
   # salt does not support specifying the UNIX socket location here - as a workaround,
   # use the MYSQL_UNIX_PORT environment variable used by libmysqlclient

--- a/public.yaml
+++ b/public.yaml
@@ -30,10 +30,8 @@ spec:
       name: salt-master-config
     - mountPath: /etc/salt/pki/master
       name: salt-master-pki
-    - mountPath: /srv/salt
-      name: salt-master
-    - mountPath: /srv/pillar
-      name: salt-pillar
+    - mountPath: /usr/share/salt/kubernetes
+      name: salt
     - mountPath: /var/run/salt/master
       name: salt-sock-dir
     - mountPath: /var/run/mysql
@@ -135,12 +133,9 @@ spec:
     - name: salt-master-pki
       hostPath:
         path: /etc/salt/pki/master
-    - name: salt-master
+    - name: salt
       hostPath:
-        path: /usr/share/salt/kubernetes/salt
-    - name: salt-pillar
-      hostPath:
-        path: /usr/share/salt/kubernetes/pillar
+        path: /usr/share/salt/kubernetes
     - name: salt-sock-dir
       hostPath:
         path: /var/run/salt/master/sock-dir


### PR DESCRIPTION
Change the mount points for Salt code and pillars, so we can either install the Salt code from RPMs **or** mount those paths from a Salt repo checkout.