### PR TITLE
activate.sh: notify that velum is starting (bsc#1031682)

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -29,3 +29,10 @@ sed -i 's|--config=/etc/kubernetes/manifests|--config=/etc/kubernetes/manifests 
 # Make sure etcd listens on 0.0.0.0
 sed -i 's@#\?ETCD_LISTEN_PEER_URLS.*@ETCD_LISTEN_PEER_URLS=http://0.0.0.0:2380@' /etc/sysconfig/etcd
 sed -i 's@#\?ETCD_LISTEN_CLIENT_URLS.*@ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379@' /etc/sysconfig/etcd
+
+# https://bugzilla.suse.com/show_bug.cgi?id=1031682
+cat <<EOF > /etc/issue.d/100-velum.conf
+You can manage your cluster by opening the web application running on
+port 80 of this node from your browser.
+
+EOF


### PR DESCRIPTION
we choose to do that in activate.sh instead of baking it into the
MicroOS, because it only refers to the controller/admin node

https://bugzilla.suse.com/show_bug.cgi?id=1031682

Signed-off-by: Maximilian Meister <mmeister@suse.de>

![welcome](https://cloud.githubusercontent.com/assets/5364817/25659205/028ca1a0-3007-11e7-8dfd-8407f9df0787.png)
