### PR TITLE
Mount MariaDB configuration under `/etc/my.cnf.d`

### DIFF
--- a/config/mysql/skip-networking.cnf
+++ b/config/mysql/skip-networking.cnf
@@ -1,1 +1,2 @@
+[mysqld]
 skip-networking

--- a/private.yaml
+++ b/private.yaml
@@ -32,8 +32,8 @@ spec:
         name: mariadb-data
       - mountPath: /var/run/mysql
         name: mariadb-unix-socket
-      - mountPath: /etc/mysql/conf.d
-        name: mariadb-config
+      - mountPath: /etc/my.cnf.d/skip-networking.cnf
+        name: mariadb-config-skip-networking
   volumes:
     - name: mariadb-data
       hostPath:
@@ -41,6 +41,6 @@ spec:
     - name: mariadb-unix-socket
       hostPath:
         path: /var/run/mysql
-    - name: mariadb-config
+    - name: mariadb-config-skip-networking
       hostPath:
-        path: /usr/share/caasp-container-manifests/config/mysql
+        path: /usr/share/caasp-container-manifests/config/mysql/skip-networking.cnf


### PR DESCRIPTION
* Under SLE the configuration lives under `/etc/my.cnf.d`
* Add `[mysqld]` section to the skip-networking file so it will be
  processed by mysqld (otherwise it's ignored)
* Mount only the `skip-networking.cnf` file, as other cnf files come
  pre-installed in `/etc/my.cnf.d` and we would be shadowing them