### PR TITLE
Kubernetes does not pick the sles12/pause image, bsc#1039863

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -24,7 +24,7 @@ cp -v $manifest_dir/private.yaml $kube_dir
 
 # Make sure that the controller node looks for the local pause image
 # TODO: remove this as soon as possible. As an idea, we could use a systemd drop-in unit.
-sed -i 's|--config=/etc/kubernetes/manifests|--config=/etc/kubernetes/manifests --pod-infra-container-image=sles12/pause:1.0.0|g' /etc/kubernetes/kubelet
+sed -i 's|^KUBELET_ARGS="--pod-manifest-path=/etc/kubernetes/manifests|KUBELET_ARGS="--pod-infra-container-image=sles12/pause:1.0.0 --pod-manifest-path=/etc/kubernetes/manifests|' /etc/kubernetes/kubelet
 
 # Make sure etcd listens on 0.0.0.0
 sed -i 's@#\?ETCD_LISTEN_PEER_URLS.*@ETCD_LISTEN_PEER_URLS=http://0.0.0.0:2380@' /etc/sysconfig/etcd


### PR DESCRIPTION
Kubernetes does not pick the sles12/pause image,
but the one from GCR on OpenStack.

After Kubernetes version upgrade KUBELET_ARGS changed and
option --config for sed regular expresion is not matched.

This change is fixing sed regular expresion for
/etc/kubernetes/kubelet config file.