### PR TITLE
Make substitution in a safer way for --pod-infra-container-image argument

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -24,7 +24,9 @@ cp -v $manifest_dir/private.yaml $kube_dir
 
 # Make sure that the controller node looks for the local pause image
 # TODO: remove this as soon as possible. As an idea, we could use a systemd drop-in unit.
-sed -i 's|^KUBELET_ARGS="--pod-manifest-path=/etc/kubernetes/manifests|KUBELET_ARGS="--pod-infra-container-image=sles12/pause:1.0.0 --pod-manifest-path=/etc/kubernetes/manifests|' /etc/kubernetes/kubelet
+if ! grep "pod-infra-container-image" /etc/kubernetes/kubelet &> /dev/null; then
+  sed -i 's|^KUBELET_ARGS="|KUBELET_ARGS="--pod-infra-container-image=sles12/pause:1.0.0 |' /etc/kubernetes/kubelet
+fi
 
 # Make sure etcd listens on 0.0.0.0
 sed -i 's@#\?ETCD_LISTEN_PEER_URLS.*@ETCD_LISTEN_PEER_URLS=http://0.0.0.0:2380@' /etc/sysconfig/etcd


### PR DESCRIPTION
This wasn't working on our production image because we are using Kubernetes 1.5
that in our config comes with the following setting in /etc/kubernetes/kubelet:

KUBELET_ARGS="--config=/etc/kubernetes/manifests"

On 1.6, --config has been completely removed and it will use --pod-manifest-path,
but not on our current installed configuration.

By adding this change, we ensure that we only make the replacement once (if the
pod-manifest-path is already there we won't do anything), and we don't rely on the
current contents for making the substitution.

Fixes: bsc#1039863