### PR TITLE
Update RPM spec for salt 2016.11.4

### DIFF
--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -47,9 +47,9 @@ Requires:       container-feeder
 Requires:       sles12-pause-1.0.0-docker-image >= 1.0.0
 Requires:       sles12-mariadb-10.0-docker-image >= 1.0.0
 Requires:       sles12-pv-recycler-node-1.0.0-docker-image >= 1.0.0
-Requires:       sles12-salt-api-2015.8.12-docker-image >= 1.0.0
-Requires:       sles12-salt-master-2015.8.12-docker-image >= 1.0.0
-Requires:       sles12-salt-minion-2015.8.12-docker-image >= 1.0.0
+Requires:       sles12-salt-api-2016.11.4-docker-image >= 1.0.0
+Requires:       sles12-salt-master-2016.11.4-docker-image >= 1.0.0
+Requires:       sles12-salt-minion-2016.11.4-docker-image >= 1.0.0
 Requires:       sles12-velum-0.0-docker-image >= 1.0.0
 # Require all  the things we mount from the host from the kubernetes-salt package
 Requires:       kubernetes-salt


### PR DESCRIPTION
As the RPM names have changed with the new tag, we need to update the spec
to require the new salt version.