### PR TITLE
use git revision in package version

### DIFF
--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -12,8 +12,9 @@ cd $(dirname $0)
 
 YEAR=$(date +%Y)
 VERSION=$(cat ../../VERSION)
-COMMIT_UNIX_TIME=$(git show -s --format=%ct)
-VERSION="${VERSION%+*}+$(date -d @$COMMIT_UNIX_TIME +%Y%m%d).$(git rev-parse --short HEAD)"
+REVISION=$(git rev-list HEAD | wc -l)
+COMMIT=$(git rev-parse --short HEAD)
+VERSION="${VERSION%+*}+git_r${REVISION}_${COMMIT}"
 NAME=$1
 
 cat <<EOF > ${NAME}.spec


### PR DESCRIPTION
this way every new package is always seen as a newer update by zypper
Otherwise using the date it can conflict if 2 commits are from the same
day

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>