### PR TITLE
Install setup folder -- we need it to mount the initialization scripts

### DIFF
--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -75,7 +75,7 @@ for dir in mysql salt/grains salt/minion.d-ca; do
   install -d %{buildroot}/%{_datadir}/%{name}/config/\$dir
   install config/\$dir/* %{buildroot}/%{_datadir}/%{name}/config/\$dir
 done
-install -d %{buildroot}/%{_datadir}/%{name}/setup
+cp -R setup %{buildroot}/%{_datadir}/%{name}
 
 
 %files


### PR DESCRIPTION
Related to hardcoded secrets removal, was a bug in the packaging side