### PR TITLE
Added admin as a salt minion

### DIFF
--- a/config/salt/grains/admin
+++ b/config/salt/grains/admin
@@ -1,0 +1,2 @@
+roles:
+- admin

--- a/config/salt/minion.d-admin/minion.conf
+++ b/config/salt/minion.d-admin/minion.conf
@@ -1,0 +1,2 @@
+id: admin
+master: localhost

--- a/config/salt/minion.d-admin/signing_policies.conf
+++ b/config/salt/minion.d-admin/signing_policies.conf
@@ -1,0 +1,10 @@
+x509_signing_policies:
+  minion:
+    - minions: '*'
+    - signing_private_key: /etc/pki/admin.key
+    - signing_cert: /etc/pki/admin.crt
+    - basicConstraints: "critical CA:false"
+    - keyUsage: "critical keyEncipherment"
+    - subjectKeyIdentifier: hash
+    - authorityKeyIdentifier: keyid,issuer:always
+    - copypath: /etc/pki/issued_certs/

--- a/public.yaml
+++ b/public.yaml
@@ -164,6 +164,21 @@ spec:
       readOnly: True
     - mountPath: /etc/salt/pki/minion
       name: salt-minion-pki
+  - name: salt-minion-admin
+    image: sles12/salt-minion:2016.11.4
+    volumeMounts:
+    - mountPath: /etc/pki
+      name: salt-minion-admin-certificates
+    - mountPath: /etc/salt/minion.d/minion.conf
+      name: salt-minion-admin-config
+      readOnly: True
+    - mountPath: /etc/salt/minion.d/signing_policies.conf
+      name: salt-minion-admin-signing-policies
+      readOnly: True
+    - mountPath: /etc/salt/grains
+      name: salt-minion-admin-grains
+    - mountPath: /etc/salt/pki/minion
+      name: salt-minion-pki
   - name: velum-dashboard
     image: sles12/velum:0.0
     env:
@@ -296,3 +311,15 @@ spec:
     - name: infra-secrets
       hostPath:
         path: /var/lib/misc/infra-secrets
+    - name: salt-minion-admin-certificates
+      hostPath:
+        path: /etc/pki
+    - name: salt-minion-admin-grains
+      hostPath:
+        path: /usr/share/caasp-container-manifests/config/salt/grains/admin
+    - name: salt-minion-admin-config
+      hostPath:
+        path: /usr/share/caasp-container-manifests/config/salt/minion.d-admin/minion.conf
+    - name: salt-minion-admin-signing-policies
+      hostPath:
+        path: /usr/share/caasp-container-manifests/config/salt/minion.d-admin/signing_policies.conf


### PR DESCRIPTION
Since kubic-project/velum#185, the admin is also handled through Salt.
I've added this files so they can be used for the development
environment.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>