### PR TITLE
Connect the `salt-minion` in the administration dashboard machine to the `salt-master`

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -46,3 +46,14 @@ if ! [ -f /root/.ssh/id_rsa ]; then
 fi
 [ -d /var/lib/misc/ssh-public-key  ] || mkdir -p /var/lib/misc/ssh-public-key
 cp /root/.ssh/id_rsa.pub /var/lib/misc/ssh-public-key
+
+# Connect the salt-minion running in the administration controller node to the local salt-master
+# instance that is running in a container
+cat <<EOF > /etc/salt/grains
+roles:
+- admin
+EOF
+echo "master: localhost" > /etc/salt/minion.d/minion.conf
+echo "id: admin" > /etc/salt/minion.d/minion_id.conf
+
+systemctl enable salt-minion


### PR DESCRIPTION
Set the `admin` role to the administration dashboard machine, as well
as the minion configuration (`id` and `master` location).

This way we will leave the `salt-minion` in the administration dashboard
connected to the `salt-master` for future orchestrated upgrades.