### PR TITLE
Add `cert-init.yaml` manifest that will initialize certificates

### DIFF
--- a/cert-init.yaml
+++ b/cert-init.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cert-init
+  labels:
+    name: cert-init
+spec:
+  hostNetwork: true
+  restartPolicy: OnFailure
+  containers:
+    - name: cert-init
+      image: sles12/salt-minion:2016.11.4
+      command: ["/init-certs.sh"]
+      volumeMounts:
+        - mountPath: /init-certs.sh
+          name: init-certs
+          readOnly: True
+        - mountPath: /etc/salt/minion.d/minion.conf
+          name: salt-minion-cert-init-config
+          readOnly: True
+        - mountPath: /etc/pki
+          name: salt-minion-ca-certificates
+          readOnly: True
+        - mountPath: /salt-init-certs-minion-pki
+          name: salt-init-certs-minion-pki
+          readOnly: True
+  volumes:
+    - name: init-certs
+      hostPath:
+        path: /usr/share/caasp-container-manifests/setup/certs/init-certs.sh
+    - name: salt-init-certs-minion-pki
+      hostPath:
+        path: /etc/salt/pki/minion-init-certs
+    - name: salt-minion-cert-init-config
+      hostPath:
+        path: /usr/share/caasp-container-manifests/config/salt/minion.d-cert-init/minion.conf
+    - name: salt-minion-ca-certificates
+      hostPath:
+        path: /etc/pki

--- a/config/salt/minion.d-ca/signing_policies.conf
+++ b/config/salt/minion.d-ca/signing_policies.conf
@@ -1,5 +1,5 @@
 x509_signing_policies:
-  minion:
+  internal:
     - minions: '*'
     - signing_private_key: /etc/pki/ca.key
     - signing_cert: /etc/pki/ca.crt
@@ -7,4 +7,13 @@ x509_signing_policies:
     - keyUsage: "critical keyEncipherment"
     - subjectKeyIdentifier: hash
     - authorityKeyIdentifier: keyid,issuer:always
-    - copypath: /etc/pki/issued_certs/
+    - copypath: /etc/pki/issued_certs/internal/
+  external:
+    - minions: '*'
+    - signing_private_key: /etc/pki/public-ca.key
+    - signing_cert: /etc/pki/public-ca.crt
+    - basicConstraints: "critical CA:false"
+    - keyUsage: "critical keyEncipherment"
+    - subjectKeyIdentifier: hash
+    - authorityKeyIdentifier: keyid,issuer:always
+    - copypath: /etc/pki/issued_certs/external/

--- a/config/salt/minion.d-cert-init/minion.conf
+++ b/config/salt/minion.d-cert-init/minion.conf
@@ -1,0 +1,2 @@
+id: cert-init
+master: localhost

--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -67,7 +67,7 @@ and velum containers on a controller node.
 %build
 
 %install
-for file in public.yaml private.yaml; do
+for file in public.yaml private.yaml cert-init.yaml; do
   install -D -m 0644 \$file %{buildroot}/%{_datadir}/%{name}/\$file
 done
 install -D -m 0755 activate.sh %{buildroot}/%{_datadir}/%{name}/activate.sh

--- a/public.yaml
+++ b/public.yaml
@@ -63,23 +63,7 @@ metadata:
       {
         "name": "salt-minion-key-generation",
         "image": "sles12/salt-master:2016.11.4",
-        "command": ["sh", "-c", "umask 377;
-                                 mkdir /salt-master-pki/minions/;
-                                 temp_dir=`mktemp -d`;
-                                 if [ ! -f /salt-admin-minion-pki/minion.pub ] || [ ! -f /salt-admin-minion-pki/minion.pem ]; then
-                                   salt-key -u root --gen-keys=admin --gen-keys-dir $temp_dir;
-                                   cp $temp_dir/admin.pub /salt-master-pki/minions/admin;
-                                   mv $temp_dir/admin.pub /salt-admin-minion-pki/minion.pub;
-                                   mv $temp_dir/admin.pem /salt-admin-minion-pki/minion.pem;
-                                 fi;
-                                 if [ ! -f /salt-ca-minion-pki/minion.pub ] || [ ! -f /tmp/ca.pem /salt-ca-minion-pki/minion.pem ]; then
-                                   salt-key -u root --gen-keys=ca --gen-keys-dir $temp_dir;
-                                   cp $temp_dir/ca.pub /salt-master-pki/minions/ca;
-                                   mv $temp_dir/ca.pub /salt-ca-minion-pki/minion.pub;
-                                   mv $temp_dir/ca.pem /salt-ca-minion-pki/minion.pem;
-                                 fi;
-                                 rm -rf $temp_dir;
-                                 exit 0"],
+        "command": ["/init-salt-keys.sh"],
         "volumeMounts": [
           {
             "mountPath": "/salt-master-pki",
@@ -92,6 +76,19 @@ metadata:
           {
             "mountPath": "/salt-admin-minion-pki",
             "name": "salt-admin-minion-pki"
+          },
+          {
+            "mountPath": "/salt-init-certs-minion-pki",
+            "name": "salt-init-certs-minion-pki"
+          },
+          {
+            "mountPath": "/etc/pki",
+            "name": "salt-minion-ca-certificates"
+          },
+          {
+            "mountPath": "/init-salt-keys.sh",
+            "name": "init-salt-keys",
+            "readOnly": true
           }
         ]
       },
@@ -130,6 +127,9 @@ spec:
     - name: SALTAPI_PASSWORD_FILE
       value: /var/lib/misc/infra-secrets/saltapi-password
     volumeMounts:
+    - mountPath: /etc/pki
+      name: salt-minion-ca-certificates
+      readOnly: True
     - mountPath: /etc/salt/master.d/master.conf
       name: salt-master-config-master-conf
       readOnly: True
@@ -165,6 +165,9 @@ spec:
   - name: salt-api
     image: sles12/salt-api:2016.11.4
     volumeMounts:
+    - mountPath: /etc/pki
+      name: salt-minion-ca-certificates
+      readOnly: True
     - mountPath: /etc/salt/master.d/master.conf
       name: salt-master-config-master-conf
       readOnly: True
@@ -213,7 +216,7 @@ spec:
     - name: VELUM_SECRETS_DIR
       value: /var/lib/misc/velum-secrets
     - name: VELUM_PORT
-      value: "80"
+      value: "443"
     - name: VELUM_DB_HOST
       value:
     - name: VELUM_DB_USERNAME
@@ -231,6 +234,8 @@ spec:
     - name: VELUM_SALT_PASSWORD_FILE
       value: /var/lib/misc/infra-secrets/saltapi-password
     volumeMounts:
+      - mountPath: /etc/pki
+        name: salt-minion-ca-certificates
       - mountPath: /var/run/mysql
         name: mariadb-unix-socket
       - mountPath: /var/lib/misc/velum-secrets
@@ -242,6 +247,37 @@ spec:
         name: infra-secrets
         readOnly: True
     args: ["bin/init"]
+  - name: velum-dashboard-autoyast
+    image: sles12/velum:0.0
+    env:
+    - name: RAILS_ENV
+      value: production
+    - name: VELUM_SECRETS_DIR
+      value: /var/lib/misc/velum-secrets
+    - name: VELUM_PORT
+      value: "80"
+    - name: VELUM_DB_HOST
+      value:
+    - name: VELUM_DB_USERNAME
+      value: "velum"
+    - name: VELUM_DB_PASSWORD_FILE
+      value: /var/lib/misc/infra-secrets/mariadb-velum-password
+    - name: VELUM_DB_SOCKET
+      value: /var/run/mysql/mysql.sock
+    volumeMounts:
+      - mountPath: /etc/pki
+        name: salt-minion-ca-certificates
+      - mountPath: /var/run/mysql
+        name: mariadb-unix-socket
+      - mountPath: /var/lib/misc/velum-secrets
+        name: velum-secrets
+      - mountPath: /var/lib/misc/ssh-public-key
+        name: ssh-public-key
+        readOnly: True
+      - mountPath: /var/lib/misc/infra-secrets
+        name: infra-secrets
+        readOnly: True
+    args: ["puma", "-C", "config/puma.rb"]
   - name: velum-event-processor
     image: sles12/velum:0.0
     env:
@@ -268,6 +304,8 @@ spec:
     - name: VELUM_SALT_PASSWORD_FILE
       value: /var/lib/misc/infra-secrets/saltapi-password
     volumeMounts:
+      - mountPath: /etc/pki
+        name: salt-minion-ca-certificates
       - mountPath: /var/run/mysql
         name: mariadb-unix-socket
       - mountPath: /var/lib/misc/velum-secrets
@@ -322,6 +360,9 @@ spec:
     - name: salt-minion-ca-certificates
       hostPath:
         path: /etc/pki
+    - name: infra-certificates
+      hostPath:
+        path: /var/lib/misc/infra-certificates
     - name: salt-minion-ca-grains
       hostPath:
         path: /usr/share/caasp-container-manifests/config/salt/grains/ca
@@ -334,12 +375,18 @@ spec:
     - name: setup-mysql
       hostPath:
         path: /usr/share/caasp-container-manifests/setup/mysql/setup-mysql.sh
+    - name: init-salt-keys
+      hostPath:
+        path: /usr/share/caasp-container-manifests/setup/salt-keys/init-salt-keys.sh
     - name: salt-ca-minion-pki
       hostPath:
         path: /etc/salt/pki/minion-ca
     - name: salt-admin-minion-pki
       hostPath:
         path: /etc/salt/pki/minion
+    - name: salt-init-certs-minion-pki
+      hostPath:
+        path: /etc/salt/pki/minion-init-certs
     - name: ssh-public-key
       hostPath:
         path: /var/lib/misc/ssh-public-key

--- a/setup/certs/init-certs.sh
+++ b/setup/certs/init-certs.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+if [ -f /etc/pki/ca.crt ] && [ -f /etc/pki/public-ca.crt ] && [ -f /etc/pki/velum.crt ] &&
+   [ -f /etc/pki/salt-api.crt ]; then
+    # The certificates have already been initialized, nothing else to do here.
+    exit 0
+fi
+
+while [ ! -f /salt-init-certs-minion-pki/minion.pem ]; do
+    sleep 1
+done
+
+salt-call event.send 'salt/cert_init'

--- a/setup/mysql/setup-mysql.sh
+++ b/setup/mysql/setup-mysql.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-umask 377;
+
+umask 377
 
 while [ ! -f /infra-secrets/mariadb-root-password ]; do
     sleep 1

--- a/setup/salt-keys/init-salt-keys.sh
+++ b/setup/salt-keys/init-salt-keys.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+umask 377
+
+mkdir -p /salt-master-pki/minions/
+temp_dir=`mktemp -d`
+
+if [ ! -f /salt-admin-minion-pki/minion.pem ]; then
+    salt-key -u root --gen-keys=admin --gen-keys-dir $temp_dir
+    cp $temp_dir/admin.pub /salt-master-pki/minions/admin
+    mv $temp_dir/admin.pub /salt-admin-minion-pki/minion.pub
+    mv $temp_dir/admin.pem /salt-admin-minion-pki/minion.pem
+fi
+
+if [ ! -f /salt-ca-minion-pki/minion.pem ]; then
+    salt-key -u root --gen-keys=ca --gen-keys-dir $temp_dir
+    cp $temp_dir/ca.pub /salt-master-pki/minions/ca
+    mv $temp_dir/ca.pub /salt-ca-minion-pki/minion.pub
+    mv $temp_dir/ca.pem /salt-ca-minion-pki/minion.pem
+fi
+
+if [ ! -f /etc/pki/ca.crt ] || [ ! -f /etc/pki/public-ca.crt ] || [ ! -f /etc/pki/velum.crt ] || [ ! -f /etc/pki/salt-api.crt ]; then
+    if [ ! -f /salt-init-certs-minion-pki/minion.pem ]; then
+       salt-key -u root --gen-keys=cert-init --gen-keys-dir $temp_dir
+       cp $temp_dir/cert-init.pub /salt-init-certs-minion-pki/minions/cert-init
+       mv $temp_dir/cert-init.pub /salt-init-certs-minion-pki/minion.pub
+       mv $temp_dir/cert-init.pem /salt-init-certs-minion-pki/minion.pem
+    fi
+fi
+
+rm -rf $temp_dir


### PR DESCRIPTION
We will initialize certificates using salt (velum and salt-api). This
new manifest will include a container that will wait for basic
initialization to happen on the `public.yaml` manifest, and then it
will signal an event to the salt-master, so it can run an orchestration
and generate the certificates for the very first services (velum and
salt-api for now).

This will only happen once, as this event will only be triggered if
the certificates aren't there yet.

Velum and salt-api services will refer to the certificates, so they
will retry to start until the certificates are present.

Fixes: bsc#1043570
Fixes: bsc#1043589

Depends on:

- https://github.com/kubic-project/salt/pull/134
- https://github.com/kubic-project/velum/pull/210
- https://github.com/kubic-project/caasp-devenv/pull/19
- https://github.com/kubic-project/e2e-tests/pull/65