### PR TITLE
bsc#1045350 Accept salt keys that have been pre-generated

### DIFF
--- a/public.yaml
+++ b/public.yaml
@@ -66,11 +66,17 @@ metadata:
         "command": ["sh", "-c", "umask 377;
                                  mkdir /salt-master-pki/minions/;
                                  temp_dir=`mktemp -d`;
+                                 if [ -f /salt-admin-minion-pki/minion.pub ] && [ -f /salt-admin-minion-pki/minion.pem ] && [ ! -f /salt-master-pki/minions/admin ]; then
+                                   cp /salt-admin-minion-pki/minion.pub /salt-master-pki/minions/admin;
+                                 fi;
                                  if [ ! -f /salt-admin-minion-pki/minion.pub ] || [ ! -f /salt-admin-minion-pki/minion.pem ]; then
                                    salt-key -u root --gen-keys=admin --gen-keys-dir $temp_dir;
                                    cp $temp_dir/admin.pub /salt-master-pki/minions/admin;
                                    mv $temp_dir/admin.pub /salt-admin-minion-pki/minion.pub;
                                    mv $temp_dir/admin.pem /salt-admin-minion-pki/minion.pem;
+                                 fi;
+                                 if [ -f /salt-ca-minion-pki/minion.pub ] && [ -f /salt-ca-minion-pki/minion.pem ] && [ ! -f /salt-master-pki/minions/ca ]; then
+                                   cp /salt-ca-minion-pki/minion.pub /salt-master-pki/minions/ca;
                                  fi;
                                  if [ ! -f /salt-ca-minion-pki/minion.pub ] || [ ! -f /tmp/ca.pem /salt-ca-minion-pki/minion.pem ]; then
                                    salt-key -u root --gen-keys=ca --gen-keys-dir $temp_dir;


### PR DESCRIPTION
Currently the admin nodes `salt-minion` starts before the container
that generates and accepts keys is ran.

This means that the salt minion is started with a key that is not
accepted, and goes to a pending state.

This checks if the key is pre-generated, and if we have accepted
a key from this minion before. If the key has been generated,
but not accepted, we accept the key and continue.