### PR TITLE
Add gen-certs script

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -16,7 +16,7 @@ sed -i 's@#\?ETCD_LISTEN_CLIENT_URLS.*@ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:23
 cat <<EOF > /etc/issue.d/90-velum.conf
 
 You can manage your cluster by opening the web application running on
-port 80 of this node from your browser.
+port 443 of this node from your browser.
 EOF
 
 # Generate root ssh key and share it with velum
@@ -35,3 +35,5 @@ roles:
 EOF
 echo "master: localhost" > /etc/salt/minion.d/minion.conf
 echo "id: admin" > /etc/salt/minion.d/minion_id.conf
+
+/usr/share/caasp-container-manifests/gen-certs.sh

--- a/config/salt/minion.d-ca/signing_policies.conf
+++ b/config/salt/minion.d-ca/signing_policies.conf
@@ -1,7 +1,7 @@
 x509_signing_policies:
   minion:
     - minions: '*'
-    - signing_private_key: /etc/pki/ca.key
+    - signing_private_key: /etc/pki/private/ca.key
     - signing_cert: /etc/pki/ca.crt
     - basicConstraints: "critical CA:false"
     - keyUsage: "critical keyEncipherment"

--- a/gen-certs.sh
+++ b/gen-certs.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+
+set -e
+
+CACN=${CACN:-CaaSP Internal CA}
+ORG=${ORG:-SUSE Internal}
+ORGUNIT=${ORGUNIT:-CaaSP}
+CITY=${CITY:-Nuremberg}
+STATE=${STATE:-Bavaria}
+COUNTRY=${COUNTRY:-DE}
+
+dir() {
+    echo "/etc/pki"
+}
+
+certs() {
+    echo "$(dir)/_certs"
+}
+
+privatedir() {
+    echo "/etc/pki/private"
+}
+
+work() {
+    echo "$(dir)/_work"
+}
+
+genca() {
+    [ -f $(privatedir)/ca.key ] && [ -f $(dir)/ca.crt ] && return
+
+    mkdir -p $(work)
+    mkdir -p $(certs)
+    mkdir -p -m 700 $(privatedir)
+
+    # generate the CA _work key
+    (umask 377 && openssl genrsa -out $(privatedir)/ca.key 4096)
+
+    cat > $(work)/ca.cfg <<EOF
+[ca]
+default_ca = CA_default
+
+[CA_default]
+dir = $(dir)
+certs	= \$dir
+database = $(work)/index.txt
+new_certs_dir	= $(certs)
+
+certificate	= \$dir/ca.crt
+serial = $(work)/serial
+private_key	= $(privatedir)/ca.key
+RANDFILE = \$dir/.rand
+
+default_days = 365
+default_md = default
+preserve = false
+copy_extensions = copy
+
+policy          = policy_match
+
+[ policy_match ]
+countryName             = match
+stateOrProvinceName     = match
+organizationName        = match
+organizationalUnitName  = optional
+commonName              = supplied
+emailAddress            = optional
+
+[req]
+distinguished_name = req_distinguished_name
+req_extensions = v3_req
+prompt = no
+
+[req_distinguished_name]
+C = $COUNTRY
+ST = $STATE
+L = $CITY
+O = $ORG
+OU = $ORGUNIT
+CN = $CACN
+
+[v3_req]
+# Extensions to add to a certificate request
+basicConstraints = CA:TRUE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+EOF
+
+    rm -f $(work)/index.txt $(work)/index.txt.attr
+    touch $(work)/index.txt $(work)/index.txt.attr
+    echo 1000 > $(work)/serial
+
+    openssl req -batch -config $(work)/ca.cfg -sha256 -new -x509 -days 3650 -key $(privatedir)/ca.key -out $(dir)/ca.crt
+}
+
+gencert() {
+    genca
+
+    [ -f $(privatedir)/$1.key ] && [ -f $(dir)/$1.crt ] && return
+
+    # generate the server cert
+    (umask 377 && openssl genrsa -out $(privatedir)/$1.key 2048)
+
+    cat > $(work)/$1.cfg <<EOF
+[req]
+distinguished_name = req_distinguished_name
+req_extensions = v3_req
+prompt = no
+
+[req_distinguished_name]
+C = $COUNTRY
+ST = $STATE
+L = $CITY
+O = $ORG
+OU = $ORGUNIT
+CN = $2
+
+[v3_req]
+# Extensions to add to a certificate request
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+subjectAltName = @alt_names
+
+[alt_names]
+EOF
+
+    count=0
+    for dnsalt in $3
+    do
+        count=$((count + 1))
+        echo "DNS.${count} = ${dnsalt}" >> $(work)/$1.cfg
+    done
+
+    count=0
+    for ipalt in $4
+    do
+        count=$((count + 1))
+        echo "IP.${count} = ${ipalt}" >> $(work)/$1.cfg
+    done
+
+    # generate the server csr
+    openssl req -batch -config $(work)/$1.cfg -new -sha256 -nodes -extensions v3_req -key $(privatedir)/$1.key -out $(work)/$1.csr
+
+    # sign the server cert
+    openssl ca -batch -config $(work)/ca.cfg -extensions v3_req -notext -in $(work)/$1.csr -out $(dir)/$1.crt
+
+    # final verification
+    openssl verify -CAfile $(dir)/ca.crt $(dir)/$1.crt
+}
+
+ip_addresses() {
+    ifconfig | grep -Po 'inet addr:\K[\d.]+' | grep -v '127.0.0.1' | tr '\n' ' '
+}
+
+all_hostnames=$(echo "$(hostname) $(hostname --fqdn) $(hostnamectl --transient) $(hostnamectl --static) \
+                      $(cat /etc/hostname)" | tr ' ' '\n' | sort -u | tr '\n' ' ')
+
+gencert "velum" "$(hostname)" "$all_hostnames" "$(ip_addresses)"
+gencert "salt-api" "salt-api.infra.caasp.local" "" "127.0.0.1"

--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -71,6 +71,7 @@ for file in public.yaml private.yaml; do
   install -D -m 0644 \$file %{buildroot}/%{_datadir}/%{name}/\$file
 done
 install -D -m 0755 activate.sh %{buildroot}/%{_datadir}/%{name}/activate.sh
+install -D -m 0755 gen-certs.sh %{buildroot}/%{_datadir}/%{name}/gen-certs.sh
 for dir in mysql salt/grains salt/minion.d-ca; do
   install -d %{buildroot}/%{_datadir}/%{name}/config/\$dir
   install config/\$dir/* %{buildroot}/%{_datadir}/%{name}/config/\$dir

--- a/public.yaml
+++ b/public.yaml
@@ -171,6 +171,15 @@ spec:
   - name: salt-api
     image: sles12/salt-api:2016.11.4
     volumeMounts:
+    - mountPath: /etc/pki/salt-api.crt
+      name: salt-api-certificate
+      readOnly: True
+    - mountPath: /etc/pki/salt-api.key
+      name: salt-api-certificate-key
+      readOnly: True
+    - mountPath: /etc/pki/ca.crt
+      name: ca-certificate
+      readOnly: True
     - mountPath: /etc/salt/master.d/master.conf
       name: salt-master-config-master-conf
       readOnly: True
@@ -219,7 +228,7 @@ spec:
     - name: VELUM_SECRETS_DIR
       value: /var/lib/misc/velum-secrets
     - name: VELUM_PORT
-      value: "80"
+      value: "443"
     - name: VELUM_DB_HOST
       value:
     - name: VELUM_DB_USERNAME
@@ -237,6 +246,15 @@ spec:
     - name: VELUM_SALT_PASSWORD_FILE
       value: /var/lib/misc/infra-secrets/saltapi-password
     volumeMounts:
+      - mountPath: /etc/pki/velum.crt
+        name: velum-certificate
+        readOnly: True
+      - mountPath: /etc/pki/velum.key
+        name: velum-certificate-key
+        readOnly: True
+      - mountPath: /etc/pki/ca.crt
+        name: ca-certificate
+        readOnly: True
       - mountPath: /var/run/mysql
         name: mariadb-unix-socket
       - mountPath: /var/lib/misc/velum-secrets
@@ -248,6 +266,35 @@ spec:
         name: infra-secrets
         readOnly: True
     args: ["bin/init"]
+  - name: velum-dashboard-autoyast
+    image: sles12/velum:0.0
+    env:
+    - name: RAILS_ENV
+      value: production
+    - name: VELUM_SECRETS_DIR
+      value: /var/lib/misc/velum-secrets
+    - name: VELUM_PORT
+      value: "80"
+    - name: VELUM_DB_HOST
+      value:
+    - name: VELUM_DB_USERNAME
+      value: "velum"
+    - name: VELUM_DB_PASSWORD_FILE
+      value: /var/lib/misc/infra-secrets/mariadb-velum-password
+    - name: VELUM_DB_SOCKET
+      value: /var/run/mysql/mysql.sock
+    volumeMounts:
+      - mountPath: /var/run/mysql
+        name: mariadb-unix-socket
+      - mountPath: /var/lib/misc/velum-secrets
+        name: velum-secrets
+      - mountPath: /var/lib/misc/ssh-public-key
+        name: ssh-public-key
+        readOnly: True
+      - mountPath: /var/lib/misc/infra-secrets
+        name: infra-secrets
+        readOnly: True
+    args: ["bundle", "exec", "puma", "-C", "config/puma.rb"]
   - name: velum-event-processor
     image: sles12/velum:0.0
     env:
@@ -274,6 +321,9 @@ spec:
     - name: VELUM_SALT_PASSWORD_FILE
       value: /var/lib/misc/infra-secrets/saltapi-password
     volumeMounts:
+      - mountPath: /etc/pki/ca.crt
+        name: ca-certificate
+        readOnly: True
       - mountPath: /var/run/mysql
         name: mariadb-unix-socket
       - mountPath: /var/lib/misc/velum-secrets
@@ -328,6 +378,21 @@ spec:
     - name: salt-minion-ca-certificates
       hostPath:
         path: /etc/pki
+    - name: velum-certificate
+      hostPath:
+        path: /etc/pki/velum.crt
+    - name: velum-certificate-key
+      hostPath:
+        path: /etc/pki/private/velum.key
+    - name: salt-api-certificate
+      hostPath:
+        path: /etc/pki/salt-api.crt
+    - name: salt-api-certificate-key
+      hostPath:
+        path: /etc/pki/private/salt-api.key
+    - name: ca-certificate
+      hostPath:
+        path: /etc/pki/ca.crt
     - name: salt-minion-ca-grains
       hostPath:
         path: /usr/share/caasp-container-manifests/config/salt/grains/ca


### PR DESCRIPTION
This script will generate a CA and both certificates for services that
require to start with TLS enabled: `velum` and `salt-api`.

Thanks to Robert Roland (@robdaemon) for providing the original script.

Fixes: bsc#1043570
Fixes: bsc#1043589