### PR TITLE
Clear TX update grains on admin node boot bsc#1045379

### DIFF
--- a/admin-node-setup.service
+++ b/admin-node-setup.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Setup admin node on every reboot
-Before=kubelet.service
+Before=kubelet.service salt-minion.service
 
 [Service]
 Type=oneshot

--- a/admin-node-setup.sh
+++ b/admin-node-setup.sh
@@ -1,9 +1,15 @@
 #!/bin/sh
 # this script WILL BE RUN ON EVERY REBOOT
 
+# Clear the transactional update grains when booting up
+if [ -f /etc/salt/grains ]; then
+    sed -i -e 's|tx_update_reboot_needed:.*|tx_update_reboot_needed: false|g' /etc/salt/grains
+fi
+
 # Update manifest files
 kube_dir=/etc/kubernetes/manifests
 manifest_dir=/usr/share/caasp-container-manifests
+
 if [ ! -d $kube_dir ]; then
     echo "$kube_dir does not exist" >&2
     echo "make sure kubernetes is installed" >&2
@@ -22,7 +28,6 @@ if [ ! -f $manifest_dir/private.yaml ]; then
     echo "private.yaml is not in $manifest_dir" >&2
     exit -3
 fi
+
 cp -v $manifest_dir/public.yaml $kube_dir
 cp -v $manifest_dir/private.yaml $kube_dir
-
-


### PR DESCRIPTION
Clear the tx_update_{reboot_needed,failed} grains upon boot. This ensures
the UI doesn't continue to show an admin node upgrade after we've upgraded.