### PR TITLE
Rename `velum-dashboard-autoyast` to `velum-autoyast`

### DIFF
--- a/public.yaml
+++ b/public.yaml
@@ -266,7 +266,7 @@ spec:
         name: infra-secrets
         readOnly: True
     args: ["bin/init"]
-  - name: velum-dashboard-autoyast
+  - name: velum-autoyast
     image: sles12/velum:0.0
     env:
     - name: RAILS_ENV


### PR DESCRIPTION
We have a lot of processes in the development, e2e-tests and debugging
environments that use `velum-dashboard`. Renaming the autoyast serving
to `velum-autoyast` will make them still only match one container, the
one they expect (actually both of them are practically the same thing,
but to keep things as they were).