### PR TITLE
Reinstate critical flag on x509 extensions

### DIFF
--- a/config/salt/minion.d-ca/signing_policies.conf
+++ b/config/salt/minion.d-ca/signing_policies.conf
@@ -3,8 +3,8 @@ x509_signing_policies:
     - minions: '*'
     - signing_private_key: /etc/pki/private/ca.key
     - signing_cert: /etc/pki/ca.crt
-    - basicConstraints: "CA:false"
-    - keyUsage: "nonRepudiation, digitalSignature, keyEncipherment"
+    - basicConstraints: "critical CA:false"
+    - keyUsage: "critical nonRepudiation, digitalSignature, keyEncipherment"
     - subjectKeyIdentifier: hash
     - authorityKeyIdentifier: keyid
     - copypath: /etc/pki/issued_certs/

--- a/gen-certs.sh
+++ b/gen-certs.sh
@@ -92,8 +92,8 @@ keyUsage = critical, nonRepudiation, digitalSignature, keyEncipherment, keyCertS
 # Extensions to add to a server certificate request
 subjectKeyIdentifier = hash
 authorityKeyIdentifier = keyid
-basicConstraints = CA:FALSE
-keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+basicConstraints = critical, CA:FALSE
+keyUsage = critical, nonRepudiation, digitalSignature, keyEncipherment
 EOF
 
     rm -f $(work)/index.txt $(work)/index.txt.attr


### PR DESCRIPTION
Reinstate the critiical flag on two x509 extenstions:

* X509v3 Basic Constraints (CA=False)
* X509v3 Key Usage (Digital Signature, Non Repudiation, Key Encipherment)

bsc#1046708