### PR TITLE
Add entries in `/etc/hosts` for hostname (bsc#1044094)

### DIFF
--- a/admin-node-setup.sh
+++ b/admin-node-setup.sh
@@ -31,3 +31,10 @@ fi
 
 cp -v $manifest_dir/public.yaml $kube_dir
 cp -v $manifest_dir/private.yaml $kube_dir
+
+h=$(hostname)
+sed -i -e "/localhost/d" /etc/hosts
+cat <<EOF>>/etc/hosts
+127.0.0.1       localhost $h
+::1             localhost ipv6-localhost ipv6-loopback $h
+EOF

--- a/public.yaml
+++ b/public.yaml
@@ -136,6 +136,9 @@ spec:
     - name: SALTAPI_PASSWORD_FILE
       value: /var/lib/misc/infra-secrets/saltapi-password
     volumeMounts:
+    - mountPath: /etc/hosts
+      name: etc-hosts
+      readOnly: True
     - mountPath: /etc/salt/master.d/master.conf
       name: salt-master-config-master-conf
       readOnly: True
@@ -333,6 +336,9 @@ spec:
         readOnly: True
     args: ["bundle", "exec", "bin/rake", "salt:process"]
   volumes:
+    - name: etc-hosts
+      hostPath:
+        path: /etc/hosts
     - name: mariadb-unix-socket
       hostPath:
         path: /var/run/mysql


### PR DESCRIPTION
In order to get rid of the IPv4/IPv6 grain rendering warnings we must introduce some entries in `/etc/hosts` where the _hostname_ is resolved to the local IPs (IPv4 and IPv6) (the IPs are not really important as long as they are there).

Caveats and limitations:
* these entries will not be updated on `hostname` changes (I think we would need a new beacon for that).
* unconfigured hosts will contain entries like:

    ```
    127.0.0.1  linux
    ::ffff:127.0.0.1  linux
    ```
* `127.0.0.1` will probably have two entries in `/etc/hosts` (not a big deal, specially for `127.0.0.1`)

