### PR TITLE
set workers to 1 for the autoyast container

### DIFF
--- a/public.yaml
+++ b/public.yaml
@@ -283,6 +283,8 @@ spec:
       value: /var/lib/misc/infra-secrets/mariadb-velum-password
     - name: VELUM_DB_SOCKET
       value: /var/run/mysql/mysql.sock
+    - name: VELUM_WORKERS
+      value: "1"
     volumeMounts:
       - mountPath: /var/run/mysql
         name: mariadb-unix-socket


### PR DESCRIPTION
this instance of velum will likely not handle many concurrent
requests

Signed-off-by: Maximilian Meister <mmeister@suse.de>


## DEPENDS ON
https://github.com/kubic-project/velum/pull/257