### PR TITLE
Add `ca.crt` to the `mine_functions` so it's published when the salt-minion starts

### DIFF
--- a/config/salt/minion.d-ca/minion.conf
+++ b/config/salt/minion.d-ca/minion.conf
@@ -1,2 +1,6 @@
 id: ca
 master: localhost
+mine_functions:
+  ca.crt:
+    mine_function: x509.get_pem_entries
+    glob_path: /etc/pki/ca.crt


### PR DESCRIPTION
We cannot rely on the `ca.crt` being published during the orchestration, since
it's an async operation and we cannot reliably wait for the contents to be there
to continue with the orchestration with the current version of salt that we are
using.

For this reason, it's safer to publish the `ca.crt` contents with the `mine_functions`,
since the file will be there upon start, and it will be published when the `ca`
`salt-minion` is starting.

Fixes: bsc#1049137
Fixes: bsc#1048548