### PR TITLE
Cache the grains on the `ca` container

### DIFF
--- a/config/salt/minion.d-ca/minion.conf
+++ b/config/salt/minion.d-ca/minion.conf
@@ -1,2 +1,3 @@
 id: ca
 master: localhost
+grains_cache: True


### PR DESCRIPTION
Rendering grains on the `ca` takes a fair amount of time if they are
not cached, as lots of grains are falling back to other cases, making
other calls like `publish.publish` timeout (timeouts by default after
5 seconds).

Forcing the grains cache will be slow only the first time, when the
grains get populated, and will get cached, making future uses faster.

Fixes: bsc#1049886