### PR TITLE
[1.0] - Improve comment about how to access velum

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -38,7 +38,7 @@ VELUM_CRT_FINGERPRINT_SHA256=$(openssl x509 -noout -in /etc/pki/velum.crt -finge
 cat <<EOF > /etc/issue.d/90-velum.conf
 
 You can manage your cluster by opening the web application running on
-port 443 of this node from your browser.
+port 443 of this node from your browser: https://<this-node>
 
 You can also check that the instance you are accessing matches the
 certificate fingerprints presented to your browser:


### PR DESCRIPTION
Be explicit about using `https://`, some users tried to access velum
using `http://velum-ip:443`.

Fixes bsc#1047310

(cherry picked from commit 16553956d341321e7733eab36679b88b631dd4b2)

This is a backport of https://github.com/kubic-project/caasp-container-manifests/pull/85