### PR TITLE
etcd on admin node does not have any peers

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -9,7 +9,6 @@ if ! grep "pod-infra-container-image" /etc/kubernetes/kubelet &> /dev/null; then
 fi
 
 # Make sure etcd listens on 0.0.0.0
-sed -i 's@#\?ETCD_LISTEN_PEER_URLS.*@ETCD_LISTEN_PEER_URLS=http://0.0.0.0:2380@' /etc/sysconfig/etcd
 sed -i 's@#\?ETCD_LISTEN_CLIENT_URLS.*@ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379@' /etc/sysconfig/etcd
 
 # Generate root ssh key and share it with velum


### PR DESCRIPTION
As such, there is no reason to listen on 0.0.0.0 for
peering.

With etcd 3.2.4, this configuration actually does not
work, giving an error:

    Aug 11 15:15:55 caasp-admin etcd[2688]: --initial-cluster must include default=http://10.17.1.0:2380 given --initial-advertise-peer-urls=http://10.17.1.0:2380

Since we don't actually peer, the simplest solution is
to just not half configure peering.