### PR TITLE
disable haproxy and flannel dependencies temporarily

### DIFF
--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -54,8 +54,9 @@ Requires:       sles12-salt-api-docker-image >= 1.0.0
 Requires:       sles12-salt-master-docker-image >= 1.0.0
 Requires:       sles12-salt-minion-docker-image >= 1.0.0
 Requires:       sles12-velum-docker-image >= 1.0.0
-Requires:       sles12-haproxy-docker-image >= 1.0.0
-Requires:       sles12-flannel-docker-image >= 1.0.0
+# Enable haproxy and flannel images, once they have been accepted into the iso
+# Requires:       sles12-haproxy-docker-image >= 1.0.0
+# Requires:       sles12-flannel-docker-image >= 1.0.0
 # Require all  the things we mount from the host from the kubernetes-salt package
 Requires:       kubernetes-salt
 BuildArch:      noarch


### PR DESCRIPTION
They can not be added until they are in the iso. Once they are in the
iso, we can enable them back