### PR TITLE
update requirements of docker images

### DIFF
--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -47,13 +47,13 @@ Group:          System/Management
 Source:         ${SAFE_BRANCH}.tar.gz
 Requires:       container-feeder
 # Require all the docker images
-Requires:       sles12-pause-docker-image >= 1.0.0
-Requires:       sles12-mariadb-docker-image >= 1.0.0
-Requires:       sles12-pv-recycler-node-docker-image >= 1.0.0
-Requires:       sles12-salt-api-docker-image >= 1.0.0
-Requires:       sles12-salt-master-docker-image >= 1.0.0
-Requires:       sles12-salt-minion-docker-image >= 1.0.0
-Requires:       sles12-velum-docker-image >= 1.0.0
+Requires:       sles12-pause-docker-image >= 1.1.0
+Requires:       sles12-mariadb-docker-image >= 1.1.0
+Requires:       sles12-pv-recycler-node-docker-image >= 1.1.0
+Requires:       sles12-salt-api-docker-image >= 1.1.0
+Requires:       sles12-salt-master-docker-image >= 1.1.0
+Requires:       sles12-salt-minion-docker-image >= 1.1.0
+Requires:       sles12-velum-docker-image >= 1.1.0
 # Require all  the things we mount from the host from the kubernetes-salt package
 Requires:       kubernetes-salt
 BuildArch:      noarch


### PR DESCRIPTION
admin-node-setup.sh script expects images to have a .tag file in
order to substitute the __TAG__ tags in public.yaml and private.yaml

This .tag is in the update images, which are >= 1.1.0

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>

Backport of https://github.com/kubic-project/caasp-container-manifests/pull/98