### PR TITLE
update image requirements

### DIFF
--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -47,18 +47,18 @@ Group:          System/Management
 Source:         ${SAFE_BRANCH}.tar.gz
 Requires:       container-feeder
 # Require all the docker images
-Requires:       sles12-pause-docker-image >= 1.1.0
-Requires:       sles12-mariadb-docker-image >= 1.1.0
-Requires:       sles12-pv-recycler-node-docker-image >= 1.1.0
-Requires:       sles12-salt-api-docker-image >= 1.1.0
-Requires:       sles12-salt-master-docker-image >= 1.1.0
-Requires:       sles12-salt-minion-docker-image >= 1.1.0
-Requires:       sles12-velum-docker-image >= 1.1.0
-Requires:       sles12-haproxy-docker-image >= 1.1.0
-Requires:       sles12-flannel-docker-image >= 1.1.0
-Requires:       sles12-dnsmasq-nanny-docker-image >= 1.1.0
-Requires:       sles12-kubedns-docker-image >= 1.1.0
-Requires:       sles12-sidecar-docker-image >= 1.1.0
+Requires:       sles12-pause-image >= 2.0.0
+Requires:       sles12-mariadb-image >= 2.0.0
+Requires:       sles12-pv-recycler-node-image >= 2.0.0
+Requires:       sles12-salt-api-image >= 2.0.0
+Requires:       sles12-salt-master-image >= 2.0.0
+Requires:       sles12-salt-minion-image >= 2.0.0
+Requires:       sles12-velum-image >= 2.0.0
+Requires:       sles12-haproxy-image >= 2.0.0
+Requires:       sles12-flannel-image >= 2.0.0
+Requires:       sles12-dnsmasq-nanny-image >= 2.0.0
+Requires:       sles12-kubedns-image >= 2.0.0
+Requires:       sles12-sidecar-image >= 2.0.0
 # Require all  the things we mount from the host from the kubernetes-salt package
 Requires:       kubernetes-salt
 BuildArch:      noarch


### PR DESCRIPTION
For CAASP 2.0, image version is > 2.0 and we have renamed the images to
not contain "docker" in its name.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>