### PR TITLE
Put the OpenLDAP config db and data db on the host

### DIFF
--- a/public.yaml
+++ b/public.yaml
@@ -325,6 +325,12 @@ spec:
       - mountPath: /var/lib/misc/infra-secrets
         name: infra-secrets
         readOnly: True
+      - mountPath: /var/lib/ldap
+        name: openldap-data
+      # these files are generated during first run of openldap
+      # if this folder is lost, TLS and other things stop working
+      - mountPath: /etc/openldap/slapd.d
+        name: openldap-config
   - name: velum-autoyast
     image: sles12/velum:__TAG__
     env:
@@ -412,6 +418,12 @@ spec:
         readOnly: True
     args: ["bundle", "exec", "bin/rake", "salt:process"]
   volumes:
+    - name: openldap-data
+      hostPath:
+        path: /var/lib/misc/ldap
+    - name: openldap-config
+      hostPath:
+        path: /var/lib/misc/ldap-config
     - name: mariadb-unix-socket
       hostPath:
         path: /var/run/mysql


### PR DESCRIPTION
OpenLDAP did not put its configuration database and data database on the
admin node's filesystem, so if the OpenLDAP container restarted, all
login data and TLS configuration data were lost.

Fixes bsc#1059407