### PR TITLE
Allow custom options to be passed to the Salt Master

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -28,6 +28,16 @@ EOF
 echo "master: localhost" > /etc/salt/minion.d/minion.conf
 echo "id: admin" > /etc/salt/minion.d/minion_id.conf
 
+# First time setup of user-configuration for salt-master
+if [ ! -d "/etc/caasp" ]; then
+	mkdir /etc/caasp
+fi
+
+if [ ! -f "/etc/caasp/salt-master-custom.conf" ]; then
+	echo "# Custom Configurations for Salt-Master" > /etc/caasp/salt-master-custom.conf
+fi
+
+# Generate TLS CA and Initial Certificates
 /usr/share/caasp-container-manifests/gen-certs.sh
 
 VELUM_CRT_FINGERPRINT_SHA1=$(openssl x509 -noout -in /etc/pki/velum.crt -fingerprint -sha1 | cut -d= -f2)

--- a/public.yaml
+++ b/public.yaml
@@ -151,23 +151,26 @@ spec:
     - name: SALTAPI_PASSWORD_FILE
       value: /var/lib/misc/infra-secrets/saltapi-password
     volumeMounts:
-    - mountPath: /etc/salt/master.d/master.conf
+    - mountPath: /etc/salt/master.d/50-master.conf
       name: salt-master-config-master-conf
       readOnly: True
-    - mountPath: /etc/salt/master.d/api.conf
+    - mountPath: /etc/salt/master.d/50-api.conf
       name: salt-master-config-api-conf
       readOnly: True
-    - mountPath: /etc/salt/master.d/peer.conf
+    - mountPath: /etc/salt/master.d/50-peer.conf
       name: salt-master-config-peer-conf
       readOnly: True
-    - mountPath: /etc/salt/master.d/reactor.conf
+    - mountPath: /etc/salt/master.d/50-reactor.conf
       name: salt-master-config-reactor-conf
       readOnly: True
-    - mountPath: /etc/salt/master.d/returner.conf
+    - mountPath: /etc/salt/master.d/50-returner.conf
       name: salt-master-config-returner-conf
       readOnly: True
     - mountPath: /etc/salt/master.d/returner-credentials.conf
       name: salt-master-config-returner-credentials-conf
+      readOnly: True
+    - mountPath: /etc/salt/master.d/75-custom.conf
+      name: salt-master-config-custom-conf
       readOnly: True
     - mountPath: /var/cache/salt
       name: salt-master-cache
@@ -195,23 +198,26 @@ spec:
     - mountPath: /etc/pki/ca.crt
       name: ca-certificate
       readOnly: True
-    - mountPath: /etc/salt/master.d/master.conf
+    - mountPath: /etc/salt/master.d/50-master.conf
       name: salt-master-config-master-conf
       readOnly: True
-    - mountPath: /etc/salt/master.d/api.conf
+    - mountPath: /etc/salt/master.d/50-api.conf
       name: salt-master-config-api-conf
       readOnly: True
-    - mountPath: /etc/salt/master.d/peer.conf
+    - mountPath: /etc/salt/master.d/50-peer.conf
       name: salt-master-config-peer-conf
       readOnly: True
-    - mountPath: /etc/salt/master.d/reactor.conf
+    - mountPath: /etc/salt/master.d/50-reactor.conf
       name: salt-master-config-reactor-conf
       readOnly: True
-    - mountPath: /etc/salt/master.d/returner.conf
+    - mountPath: /etc/salt/master.d/50-returner.conf
       name: salt-master-config-returner-conf
       readOnly: True
     - mountPath: /etc/salt/master.d/returner-credentials.conf
       name: salt-master-config-returner-credentials-conf
+      readOnly: True
+    - mountPath: /etc/salt/master.d/75-custom.conf
+      name: salt-master-config-custom-conf
       readOnly: True
     - mountPath: /var/cache/salt
       name: salt-master-cache
@@ -438,22 +444,25 @@ spec:
         path: /var/lib/misc/salt-master-credentials
     - name: salt-master-config-master-conf
       hostPath:
-        path: /usr/share/salt/kubernetes/config/master.d/master.conf
+        path: /usr/share/salt/kubernetes/config/master.d/50-master.conf
     - name: salt-master-config-api-conf
       hostPath:
-        path: /usr/share/salt/kubernetes/config/master.d/api.conf
+        path: /usr/share/salt/kubernetes/config/master.d/50-api.conf
     - name: salt-master-config-peer-conf
       hostPath:
-        path: /usr/share/salt/kubernetes/config/master.d/peer.conf
+        path: /usr/share/salt/kubernetes/config/master.d/50-peer.conf
     - name: salt-master-config-reactor-conf
       hostPath:
-        path: /usr/share/salt/kubernetes/config/master.d/reactor.conf
+        path: /usr/share/salt/kubernetes/config/master.d/50-reactor.conf
     - name: salt-master-config-returner-conf
       hostPath:
-        path: /usr/share/salt/kubernetes/config/master.d/returner.conf
+        path: /usr/share/salt/kubernetes/config/master.d/50-returner.conf
     - name: salt-master-config-returner-credentials-conf
       hostPath:
         path: /var/lib/misc/salt-master-credentials/returner-credentials.conf
+    - name: salt-master-config-custom-conf
+      hostPath:
+        path: /etc/caasp/salt-master-custom.conf
     - name: salt-master-pki
       hostPath:
         path: /etc/salt/pki/master


### PR DESCRIPTION
Create a file for custom salt-master configuration options
to be supplied. This will be loaded in numeric order, allowing
for certain options (e.g. worker thread counts).

bsc#1059724