### PR TITLE
Mount public cloud config file to velum

### DIFF
--- a/public.yaml
+++ b/public.yaml
@@ -308,6 +308,9 @@ spec:
       - mountPath: /var/lib/misc/infra-secrets
         name: infra-secrets
         readOnly: True
+      - mountPath: /etc/caasp/caasp-cloud.cfg
+        name: public-cloud-config
+        readOnly: True
     args: ["bin/init"]
   - name: openldap
     image: sles12/openldap:__TAG__
@@ -523,3 +526,6 @@ spec:
     - name: infra-secrets
       hostPath:
         path: /var/lib/misc/infra-secrets
+    - name: public-cloud-config
+      hostPath:
+        path: /etc/caasp/caasp-cloud.cfg


### PR DESCRIPTION
/etc/caasp/caasp-cloud.cfg is an INI-style config file supplying data
about the CSP in which velum is operating, allowing for internally
distinguishing the appropriate behavior in each cloud environment.

Images for each CSP will carry a different config file. See
https://github.com/SUSE/pubcloud/pull/193
for more details.