### PR TITLE
Re-add the sle12-flannel-image

### DIFF
--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -55,6 +55,7 @@ Requires:       sles12-salt-master-image >= 2.0.0
 Requires:       sles12-salt-minion-image >= 2.0.0
 Requires:       sles12-velum-image >= 2.0.0
 Requires:       sles12-haproxy-image >= 2.0.0
+Requires:       sles12-flannel-docker-image >= 2.0.0
 Requires:       sles12-dnsmasq-nanny-image >= 2.0.0
 Requires:       sles12-kubedns-image >= 2.0.0
 Requires:       sles12-sidecar-image >= 2.0.0


### PR DESCRIPTION
Include [this package](https://build.suse.de/package/show/Devel:CASP:Head:ControllerNode/sles12sp3-flannel-image) in the CaaSP image.