### PR TITLE
kubelet: switch deprecated --config flag to --kubeconfig

### DIFF
--- a/admin-node-setup.sh
+++ b/admin-node-setup.sh
@@ -48,3 +48,6 @@ cp $tmp_dir/public.yaml $kube_dir
 cp $tmp_dir/private.yaml $kube_dir
 
 rm -rf $tmp_dir
+
+# switch deprecated --config flag in kubelet
+sed -i -e "s/--config=/--pod-manifest-path=/g" /etc/kubernetes/kubelet


### PR DESCRIPTION
this needs to be done during upgrade to 2.0 otherwise kubelet
wont start

Signed-off-by: Maximilian Meister <mmeister@suse.de>