### PR TITLE
Ensure LDAP cert is generated on upgrade

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -28,22 +28,3 @@ roles:
 EOF
 echo "master: localhost" > /etc/salt/minion.d/minion.conf
 echo "id: admin" > /etc/salt/minion.d/minion_id.conf
-
-# Generate TLS CA and Initial Certificates
-/usr/share/caasp-container-manifests/gen-certs.sh
-
-VELUM_CRT_FINGERPRINT_SHA1=$(openssl x509 -noout -in /etc/pki/velum.crt -fingerprint -sha1 | cut -d= -f2)
-VELUM_CRT_FINGERPRINT_SHA256=$(openssl x509 -noout -in /etc/pki/velum.crt -fingerprint -sha256 | cut -d= -f2)
-
-# https://bugzilla.suse.com/show_bug.cgi?id=1031682
-cat <<EOF > /etc/issue.d/90-velum.conf
-
-You can manage your cluster by opening the web application running on
-port 443 of this node from your browser: https://<this-node>
-
-You can also check that the instance you are accessing matches the
-certificate fingerprints presented to your browser:
-
-Velum SHA1 fingerprint:   $VELUM_CRT_FINGERPRINT_SHA1
-Velum SHA256 fingerprint: $VELUM_CRT_FINGERPRINT_SHA256
-EOF

--- a/activate.sh
+++ b/activate.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 # activate the dashboard
 # this script WILL BE RUN ONLY ONCE, after the installation
+# this script WILL NOT RUN during/after upgrades
 
 # Make sure that the controller node looks for the local pause image
 # TODO: remove this as soon as possible. As an idea, we could use a systemd drop-in unit.
@@ -27,15 +28,6 @@ roles:
 EOF
 echo "master: localhost" > /etc/salt/minion.d/minion.conf
 echo "id: admin" > /etc/salt/minion.d/minion_id.conf
-
-# First time setup of user-configuration for salt-master
-if [ ! -d "/etc/caasp" ]; then
-	mkdir /etc/caasp
-fi
-
-if [ ! -f "/etc/caasp/salt-master-custom.conf" ]; then
-	echo "# Custom Configurations for Salt-Master" > /etc/caasp/salt-master-custom.conf
-fi
 
 # Generate TLS CA and Initial Certificates
 /usr/share/caasp-container-manifests/gen-certs.sh

--- a/admin-node-setup.sh
+++ b/admin-node-setup.sh
@@ -6,6 +6,9 @@ if [ -f /etc/salt/grains ]; then
     sed -i -e 's|tx_update_reboot_needed:.*|tx_update_reboot_needed: false|g' /etc/salt/grains
 fi
 
+# switch deprecated --config flag in kubelet
+sed -i -e "s/--config=/--pod-manifest-path=/g" /etc/kubernetes/kubelet
+
 # Update manifest files
 kube_dir=/etc/kubernetes/manifests
 manifest_dir=/usr/share/caasp-container-manifests

--- a/admin-node-setup.sh
+++ b/admin-node-setup.sh
@@ -57,3 +57,23 @@ fi
 if [ ! -f "/etc/caasp/salt-master-custom.conf" ]; then
     echo "# Custom Configurations for Salt-Master" > /etc/caasp/salt-master-custom.conf
 fi
+
+# Generate TLS CA and Initial Certificates
+/usr/share/caasp-container-manifests/gen-certs.sh
+
+VELUM_CRT_FINGERPRINT_SHA1=$(openssl x509 -noout -in /etc/pki/velum.crt -fingerprint -sha1 | cut -d= -f2)
+VELUM_CRT_FINGERPRINT_SHA256=$(openssl x509 -noout -in /etc/pki/velum.crt -fingerprint -sha256 | cut -d= -f2)
+
+# Generate issue file with Velum details
+# https://bugzilla.suse.com/show_bug.cgi?id=1031682
+cat <<EOF > /etc/issue.d/90-velum.conf
+
+You can manage your cluster by opening the web application running on
+port 443 of this node from your browser: https://<this-node>
+
+You can also check that the instance you are accessing matches the
+certificate fingerprints presented to your browser:
+
+Velum SHA1 fingerprint:   $VELUM_CRT_FINGERPRINT_SHA1
+Velum SHA256 fingerprint: $VELUM_CRT_FINGERPRINT_SHA256
+EOF

--- a/admin-node-setup.sh
+++ b/admin-node-setup.sh
@@ -48,3 +48,12 @@ cp $tmp_dir/public.yaml $kube_dir
 cp $tmp_dir/private.yaml $kube_dir
 
 rm -rf $tmp_dir
+
+# First time setup of user-configuration for salt-master
+if [ ! -d "/etc/caasp" ]; then
+    mkdir /etc/caasp
+fi
+
+if [ ! -f "/etc/caasp/salt-master-custom.conf" ]; then
+    echo "# Custom Configurations for Salt-Master" > /etc/caasp/salt-master-custom.conf
+fi


### PR DESCRIPTION
Moving the call to gen-certs.sh from activate.sh, over to admin-node-setup.sh
will ensure that any missing certs are generated upon upgrade. This will ensure
the new LDAP cert is created.

In order to preserve issue generation, which contains the Velum key fingerprint,
we must also move this to admin-node-setup.

bsc#1062022

Builds upon https://github.com/kubic-project/caasp-container-manifests/pull/122
Builds upon https://github.com/kubic-project/caasp-container-manifests/pull/121