### PR TITLE
[2.0] Follow prefix patterns for returner credentials too

### DIFF
--- a/public.yaml
+++ b/public.yaml
@@ -120,11 +120,15 @@ metadata:
         "name": "salt-master-config",
         "image": "sles12/velum:__TAG__",
         "command": ["sh", "-c", "umask 377;
-                                 rmdir /salt-master-credentials/returner-credentials.conf;
-                                 if [ ! -f /salt-master-credentials/returner-credentials.conf ]; then
-                                   echo \"mysql:\" > /salt-master-credentials/returner-credentials.conf;
-                                   echo -n \"  pass: \" >> /salt-master-credentials/returner-credentials.conf;
-                                   cat /infra-secrets/mariadb-salt-password >> /salt-master-credentials/returner-credentials.conf;
+                                 rmdir /salt-master-credentials/55-returner-credentials.conf;
+                                 if [ ! -f /salt-master-credentials/55-returner-credentials.conf ]; then
+                                   if [ -f /salt-master-credentials/returner-credentials.conf ]; then
+                                     mv /salt-master-credentials/returner-credentials.conf /salt-master-credentials/55-returner-credentials.conf;
+                                   else;
+                                     echo \"mysql:\" > /salt-master-credentials/55-returner-credentials.conf;
+                                     echo -n \"  pass: \" >> /salt-master-credentials/55-returner-credentials.conf;
+                                     cat /infra-secrets/mariadb-salt-password >> /salt-master-credentials/55-returner-credentials.conf;
+                                   fi;
                                  fi;
                                  exit 0"],
         "volumeMounts": [
@@ -166,7 +170,7 @@ spec:
     - mountPath: /etc/salt/master.d/50-returner.conf
       name: salt-master-config-returner-conf
       readOnly: True
-    - mountPath: /etc/salt/master.d/returner-credentials.conf
+    - mountPath: /etc/salt/master.d/55-returner-credentials.conf
       name: salt-master-config-returner-credentials-conf
       readOnly: True
     - mountPath: /etc/salt/master.d/75-custom.conf
@@ -213,7 +217,7 @@ spec:
     - mountPath: /etc/salt/master.d/50-returner.conf
       name: salt-master-config-returner-conf
       readOnly: True
-    - mountPath: /etc/salt/master.d/returner-credentials.conf
+    - mountPath: /etc/salt/master.d/55-returner-credentials.conf
       name: salt-master-config-returner-credentials-conf
       readOnly: True
     - mountPath: /etc/salt/master.d/75-custom.conf
@@ -459,7 +463,7 @@ spec:
         path: /usr/share/salt/kubernetes/config/master.d/50-returner.conf
     - name: salt-master-config-returner-credentials-conf
       hostPath:
-        path: /var/lib/misc/salt-master-credentials/returner-credentials.conf
+        path: /var/lib/misc/salt-master-credentials/55-returner-credentials.conf
     - name: salt-master-config-custom-conf
       hostPath:
         path: /etc/caasp/salt-master-custom.conf


### PR DESCRIPTION
As has been introduced in 17a0d8d8ac58ee8cb6d79849219b5631a60afa1e

Backport of https://github.com/kubic-project/caasp-container-manifests/pull/115