### PR TITLE
Wait for network before running admin-node-setup.service

### DIFF
--- a/admin-node-setup.service
+++ b/admin-node-setup.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Setup admin node on every reboot
 Before=kubelet.service salt-minion.service
+After=network.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
As we need to know the IPs and hostnames for use in the TLS certificates
this generates, we should ensure the network is up and running before this
unit triggers.

bsc#1062284