### PR TITLE
Export /etc/hosts from host to velum-dashboard pod, bsc#1062728

### DIFF
--- a/public.yaml
+++ b/public.yaml
@@ -308,6 +308,9 @@ spec:
       - mountPath: /var/lib/misc/infra-secrets
         name: infra-secrets
         readOnly: True
+      - mountPath: /etc/hosts
+        name: etc-hosts
+        readOnly: True
     args: ["bin/init"]
   - name: openldap
     image: sles12/openldap:__TAG__
@@ -523,3 +526,6 @@ spec:
     - name: infra-secrets
       hostPath:
         path: /var/lib/misc/infra-secrets
+    - name: etc-hosts
+      hostPath:
+        path: /etc/hosts


### PR DESCRIPTION
Docker copies /etc/hosts from host during starting container,
we would like to keep /etc/hosts file updated since it is managed by salt.
The reason for this is that velum has to resolve Kube API fqdn.
Problem was discovered and discribed in bug 1062728