### PR TITLE
Use HAProxy from the beginning for Velum too.

### DIFF
--- a/admin-node-setup.sh
+++ b/admin-node-setup.sh
@@ -32,11 +32,16 @@ if [ ! -f $manifest_dir/private.yaml ]; then
     echo "private.yaml is not in $manifest_dir" >&2
     exit -3
 fi
+if [ ! -f $manifest_dir/haproxy.yaml ]; then
+    echo "haproxy.yaml is not in $manifest_dir" >&2
+    exit -3
+fi
 
 tmp_dir=$(mktemp -d)
 
 cp $manifest_dir/public.yaml $tmp_dir
 cp $manifest_dir/private.yaml $tmp_dir
+cp $manifest_dir/haproxy.yaml $tmp_dir
 
 for i in $(ls $images_dir/sles*.tag);do
     metadata_file=$(basename $i .tag).metadata
@@ -45,10 +50,12 @@ for i in $(ls $images_dir/sles*.tag);do
     echo "$0: Setting $image_name:$tag into public and private manifests"
     sed -i -e "s%$image_name:__TAG__%$image_name:$tag%g" $tmp_dir/public.yaml
     sed -i -e "s%$image_name:__TAG__%$image_name:$tag%g" $tmp_dir/private.yaml
+    sed -i -e "s%$image_name:__TAG__%$image_name:$tag%g" $tmp_dir/haproxy.yaml
 done
 echo "$0: Replacing public and private manifests"
 cp $tmp_dir/public.yaml $kube_dir
 cp $tmp_dir/private.yaml $kube_dir
+cp $tmp_dir/haproxy.yaml $kube_dir
 
 rm -rf $tmp_dir
 

--- a/config/haproxy/haproxy.cfg
+++ b/config/haproxy/haproxy.cfg
@@ -1,0 +1,34 @@
+global
+        log /dev/log    local0
+        log /dev/log    local1 notice
+        daemon
+
+defaults
+        log     global
+        mode    tcp
+        option  tcplog
+        option  dontlognull
+        timeout connect 5000
+        timeout client 50000
+        timeout server 50000
+
+listen velum
+        bind 0.0.0.0:80
+        bind 0.0.0.0:443 ssl crt /etc/pki/velum.pem ca-file /etc/pki/ca.crt
+        mode http
+        acl path_autoyast path_reg ^/autoyast$
+        option forwardfor
+        http-request set-header X-Forwarded-Proto https
+        redirect scheme https code 302 if !{ ssl_fc } !path_autoyast
+        default-server inter 10s fall 3
+        balance roundrobin
+        server velum unix@/var/run/puma/dashboard.sock
+
+listen velum-api
+        bind 127.0.0.1:443 ssl crt /etc/pki/velum.pem ca-file /etc/pki/ca.crt
+        mode http
+        option forwardfor
+        http-request set-header X-Forwarded-Proto https
+        default-server inter 10s fall 3
+        balance roundrobin
+        server velum unix@/var/run/puma/api.sock

--- a/gen-certs.sh
+++ b/gen-certs.sh
@@ -157,6 +157,8 @@ EOF
 
     # final verification
     openssl verify -CAfile $(dir)/ca.crt $(dir)/$1.crt
+
+    cat $(dir)/$1.crt $(privatedir)/$1.key > $(privatedir)/$1-bundle.pem
 }
 
 ip_addresses() {

--- a/haproxy.yaml
+++ b/haproxy.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: haproxy
+  namespace: kube-system
+  labels:
+    name: haproxy
+spec:
+  restartPolicy: Always
+  hostNetwork: true
+  tolerations:
+    - key: node-role.kubernetes.io/master
+      operator: Exists
+      effect: NoSchedule
+  containers:
+    - name: haproxy
+      image: sles12/haproxy:__TAG__
+      resources:
+        requests:
+          memory: 128Mi
+        limits:
+          memory: 128Mi
+      volumeMounts:
+        - name: haproxy-cfg
+          mountPath: /etc/haproxy
+        - name: etc-hosts
+          mountPath: /etc/hosts
+        - name: velum-bundle-certificate
+          mountPath: /etc/pki/velum.pem
+          readOnly: True
+        - name: ca-certificate
+          mountPath: /etc/pki/ca.crt
+          readOnly: True
+        - name: velum-unix-socket
+          mountPath: /var/run/puma
+  volumes:
+    - name: haproxy-cfg
+      hostPath:
+        path: /etc/haproxy
+    - name: etc-hosts
+      hostPath:
+        path: /etc/hosts
+    - name: velum-bundle-certificate
+      hostPath:
+        path: /etc/pki/private/velum-bundle.pem
+    - name: ca-certificate
+      hostPath:
+        path: /etc/pki/ca.crt
+    - name: velum-unix-socket
+      hostPath:
+        path: /var/run/puma

--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -77,9 +77,10 @@ and velum containers on a controller node.
 %build
 
 %install
-for file in public.yaml private.yaml; do
+for file in public.yaml private.yaml haproxy.yaml; do
   install -D -m 0644 \$file %{buildroot}/%{_datadir}/%{name}/\$file
 done
+install -D -m 0755 haproxy.cfg %{buildroot}/etc/haproxy/haproxy.cfg
 install -D -m 0755 activate.sh %{buildroot}/%{_datadir}/%{name}/activate.sh
 install -D -m 0755 gen-certs.sh %{buildroot}/%{_datadir}/%{name}/gen-certs.sh
 for dir in mysql salt/grains salt/minion.d-ca; do
@@ -109,6 +110,7 @@ ln -s %{_sbindir}/service %{buildroot}/%{_sbindir}/rcadmin-node-setup
 %service_del_postun admin-node-setup.service
 
 %files
+%config(noreplace) /etc/haproxy/haproxy.cfg
 %defattr(-,root,root)
 %doc LICENSE README.md
 %dir %{_datadir}/%{name}

--- a/public.yaml
+++ b/public.yaml
@@ -227,8 +227,10 @@ spec:
       value: production
     - name: VELUM_SECRETS_DIR
       value: /var/lib/misc/velum-secrets
-    - name: VELUM_PORT
-      value: "443"
+    - name: VELUM_SOCKET_NAME
+      value: dashboard.sock
+    - name: VELUM_WORKERS
+      value: "2"
     - name: VELUM_DB_HOST
       value:
     - name: VELUM_DB_USERNAME
@@ -272,17 +274,13 @@ spec:
     - name: LDAP_DOMAIN
       value: infra.caasp.local
     volumeMounts:
-    - mountPath: /etc/pki/velum.crt
-      name: velum-certificate
-      readOnly: True
-    - mountPath: /etc/pki/velum.key
-      name: velum-certificate-key
-      readOnly: True
     - mountPath: /etc/pki/ca.crt
       name: ca-certificate
       readOnly: True
     - mountPath: /var/run/mysql
       name: mariadb-unix-socket
+    - mountPath: /var/run/puma
+      name: velum-unix-socket
     - mountPath: /var/lib/misc/velum-secrets
       name: velum-secrets
     - mountPath: /var/lib/misc/ssh-public-key
@@ -292,6 +290,76 @@ spec:
       name: infra-secrets
       readOnly: True
     args: ["bin/init"]
+  - name: velum-api
+    image: sles12/velum:__TAG__
+    env:
+    - name: RAILS_ENV
+      value: production
+    - name: VELUM_SECRETS_DIR
+      value: /var/lib/misc/velum-secrets
+    - name: VELUM_SOCKET_NAME
+      value: api.sock
+    - name: VELUM_WORKERS
+      value: "6"
+    - name: VELUM_DB_HOST
+      value:
+    - name: VELUM_DB_USERNAME
+      value: "velum"
+    - name: VELUM_DB_PASSWORD_FILE
+      value: /var/lib/misc/infra-secrets/mariadb-velum-password
+    - name: VELUM_DB_SOCKET
+      value: /var/run/mysql/mysql.sock
+    - name: VELUM_SALT_HOST
+      value: "127.0.0.1"
+    - name: VELUM_SALT_PORT
+      value: "8000"
+    - name: VELUM_SALT_USER
+      value: saltapi
+    - name: VELUM_SALT_PASSWORD_FILE
+      value: /var/lib/misc/infra-secrets/saltapi-password
+    - name: VELUM_INTERNAL_API_USERNAME_FILE
+      value: /var/lib/misc/infra-secrets/velum-internal-api-username
+    - name: VELUM_INTERNAL_API_PASSWORD_FILE
+      value: /var/lib/misc/infra-secrets/velum-internal-api-password
+    - name: LDAP_HOST
+      value: "127.0.0.1"
+    - name: LDAP_PORT
+      value: "389"
+    - name: LDAP_GROUP_BASE_DN
+      value: ou=Groups,dc=infra,dc=caasp,dc=local
+    - name: LDAP_PEOPLE_BASE_DN
+      value: ou=People,dc=infra,dc=caasp,dc=local
+    - name: LDAP_BIND_DN
+      value: cn=admin,dc=infra,dc=caasp,dc=local
+    - name: LDAP_BASE_DN
+      value: dc=infra,dc=caasp,dc=local
+    - name: LDAP_ADMIN_GROUP_DN
+      value: cn=Administrators,ou=Groups,dc=infra,dc=caasp,dc=local
+    - name: LDAP_TLS_METHOD
+      value: start_tls
+    - name: LDAP_MAIL_ATTRIBUTE
+      value: mail
+    - name: LDAP_PASSWORD_FILE
+      value: /var/lib/misc/infra-secrets/openldap-password
+    - name: LDAP_DOMAIN
+      value: infra.caasp.local
+    volumeMounts:
+    - mountPath: /etc/pki/ca.crt
+      name: ca-certificate
+      readOnly: True
+    - mountPath: /var/run/mysql
+      name: mariadb-unix-socket
+    - mountPath: /var/run/puma
+      name: velum-unix-socket
+    - mountPath: /var/lib/misc/velum-secrets
+      name: velum-secrets
+    - mountPath: /var/lib/misc/ssh-public-key
+      name: ssh-public-key
+      readOnly: True
+    - mountPath: /var/lib/misc/infra-secrets
+      name: infra-secrets
+      readOnly: True
+    args: ["bundle", "exec", "puma", "-C", "config/puma.rb"]
   - name: openldap
     image: sles12/openldap:__TAG__
     env:
@@ -320,35 +388,6 @@ spec:
     # if this folder is lost, TLS and other things stop working
     - mountPath: /etc/openldap/slapd.d
       name: openldap-config
-  - name: velum-autoyast
-    image: sles12/velum:__TAG__
-    env:
-    - name: RAILS_ENV
-      value: production
-    - name: VELUM_SECRETS_DIR
-      value: /var/lib/misc/velum-secrets
-    - name: VELUM_PORT
-      value: "80"
-    - name: VELUM_DB_HOST
-      value:
-    - name: VELUM_DB_USERNAME
-      value: "velum"
-    - name: VELUM_DB_PASSWORD_FILE
-      value: /var/lib/misc/infra-secrets/mariadb-velum-password
-    - name: VELUM_DB_SOCKET
-      value: /var/run/mysql/mysql.sock
-    volumeMounts:
-    - mountPath: /var/run/mysql
-      name: mariadb-unix-socket
-    - mountPath: /var/lib/misc/velum-secrets
-      name: velum-secrets
-    - mountPath: /var/lib/misc/ssh-public-key
-      name: ssh-public-key
-      readOnly: True
-    - mountPath: /var/lib/misc/infra-secrets
-      name: infra-secrets
-      readOnly: True
-    args: ["bundle", "exec", "puma", "-C", "config/puma.rb"]
   - name: velum-event-processor
     image: sles12/velum:__TAG__
     env:
@@ -420,6 +459,9 @@ spec:
   - name: mariadb-unix-socket
     hostPath:
       path: /var/run/mysql
+  - name: velum-unix-socket
+    hostPath:
+      path: /var/run/puma
   - name: velum-secrets
     hostPath:
       path: /var/lib/misc/velum-secrets
@@ -466,12 +508,6 @@ spec:
   - name: salt-minion-ca-certificates
     hostPath:
       path: /etc/pki
-  - name: velum-certificate
-    hostPath:
-      path: /etc/pki/velum.crt
-  - name: velum-certificate-key
-    hostPath:
-      path: /etc/pki/private/velum.key
   - name: openldap-certificate
     hostPath:
       path: /etc/pki/ldap.crt


### PR DESCRIPTION
This will help us with SSL termination on HAProxy side.

- [x] Do not call to `bin/init` from two different containers, as they will setup the database the first time and run migrations afterwards. It's safer if only one container runs this while the others just raise the application server.

Depends on: https://github.com/kubic-project/velum/pull/387
Depends on: https://github.com/kubic-project/salt/pull/314