### PR TITLE
Add mount for public cloud pillar

### DIFF
--- a/manifests/public.yaml
+++ b/manifests/public.yaml
@@ -166,6 +166,9 @@ spec:
     - mountPath: /var/lib/misc/infra-secrets
       name: infra-secrets
       readOnly: True
+    - mountPath: /srv/pillar
+      name: public-cloud-config
+      readOnly: True
   - name: salt-api
     image: sles12/salt-api:__TAG__
     volumeMounts:
@@ -547,3 +550,6 @@ spec:
   - name: infra-secrets
     hostPath:
       path: /var/lib/misc/infra-secrets
+  - name: public-cloud-config
+    hostPath:
+      path: /etc/salt/pillar


### PR DESCRIPTION
To get public cloud specific configuration data to be used with salt-cloud into the salt-master container, we'd like to map the directory where we store the generated sls file into the container.