### PR TITLE
Add kubic images

### DIFF
--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -37,6 +37,18 @@ cat <<EOF > ${NAME}.spec
 # Please submit bugfixes or comments via http://bugs.opensuse.org/
 #
 
+%if 0%{?suse_version} == 1315 && !0%{?is_opensuse}
+  %define _base_image sles12
+%endif
+
+%if 0%{?suse_version} == 1500 && !0%{?is_opensuse}
+  %define _base_image sles15
+%endif
+
+%if 0%{?is_opensuse} && 0%{?suse_version} > 1500
+  %define _base_image tumbleweed
+%endif
+
 Name:           $NAME
 Version:        $VERSION
 Release:        0
@@ -47,21 +59,21 @@ Group:          System/Management
 Source:         ${SAFE_BRANCH}.tar.gz
 Requires:       container-feeder
 # Require all the docker images
-Requires:       sles12-pause-image >= 2.0.0
-Requires:       sles12-mariadb-image >= 2.0.0
-Requires:       sles12-pv-recycler-node-image >= 2.0.0
-Requires:       sles12-salt-api-image >= 2.0.0
-Requires:       sles12-salt-master-image >= 2.0.0
-Requires:       sles12-salt-minion-image >= 2.0.0
-Requires:       sles12-velum-image >= 2.0.0
-Requires:       sles12-haproxy-image >= 2.0.0
-Requires:       sles12-flannel-image >= 2.0.0
-Requires:       sles12-dnsmasq-nanny-image >= 2.0.0
-Requires:       sles12-kubedns-image >= 2.0.0
-Requires:       sles12-sidecar-image >= 2.0.0
-Requires:       sles12-tiller-image >= 2.0.0
-Requires:       sles12-openldap-image >= 2.0.0
-Requires:       sles12-caasp-dex-image >= 2.0.0
+Requires:       %{_base_image}-pause-image >= 2.0.0
+Requires:       %{_base_image}-mariadb-image >= 2.0.0
+Requires:       %{_base_image}-pv-recycler-node-image >= 2.0.0
+Requires:       %{_base_image}-salt-api-image >= 2.0.0
+Requires:       %{_base_image}-salt-master-image >= 2.0.0
+Requires:       %{_base_image}-salt-minion-image >= 2.0.0
+Requires:       %{_base_image}-velum-image >= 2.0.0
+Requires:       %{_base_image}-haproxy-image >= 2.0.0
+Requires:       %{_base_image}-flannel-image >= 2.0.0
+Requires:       %{_base_image}-dnsmasq-nanny-image >= 2.0.0
+Requires:       %{_base_image}-kubedns-image >= 2.0.0
+Requires:       %{_base_image}-sidecar-image >= 2.0.0
+Requires:       %{_base_image}-tiller-image >= 2.0.0
+Requires:       %{_base_image}-openldap-image >= 2.0.0
+Requires:       %{_base_image}-caasp-dex-image >= 2.0.0
 # Require all  the things we mount from the host from the kubernetes-salt package
 Requires:       kubernetes-salt
 BuildArch:      noarch
@@ -79,6 +91,8 @@ and velum containers on a controller node.
 %install
 for file in manifests/*.yaml; do
   install -D -m 0644 \$file %{buildroot}/%{_datadir}/%{name}/\$file
+  # fix image name
+  sed -e "s%image:[ ]*sles12/\(.*\):%image: %{_base_image}/\1:%g" -i %{buildroot}/%{_datadir}/%{name}/\$file
 done
 install -D -m 0755 config/haproxy/haproxy.cfg %{buildroot}/etc/haproxy/haproxy.cfg
 install -D -m 0755 activate.sh %{buildroot}/%{_datadir}/%{name}/activate.sh


### PR DESCRIPTION
If this package is built in tumbleweed,the images should be named
tumbleweed and not sle12.

When this builds on sle15, the images should be named sle15.

We cannot use the same name for the different suse versions as if this
images were in a registry, they should be named different.