### PR TITLE
[packaging] Use # instead of % in the sed expression

### DIFF
--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -92,7 +92,7 @@ and velum containers on a controller node.
 for file in manifests/*.yaml; do
   install -D -m 0644 \$file %{buildroot}/%{_datadir}/%{name}/\$file
   # fix image name
-  sed -e "s%image:[ ]*sles12/\(.*\):%image: %{_base_image}/\1:%g" -i %{buildroot}/%{_datadir}/%{name}/\$file
+  sed -e "s|image:[ ]*sles12/\(.*\):|image: %{_base_image}/\1:|g" -i %{buildroot}/%{_datadir}/%{name}/\$file
 done
 install -D -m 0755 config/haproxy/haproxy.cfg %{buildroot}/etc/haproxy/haproxy.cfg
 install -D -m 0755 activate.sh %{buildroot}/%{_datadir}/%{name}/activate.sh


### PR DESCRIPTION
as % is reserved for rpm macros

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>