### PR TITLE
Use base_image name as 'kubic-' for kubic images

### DIFF
--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -46,7 +46,7 @@ cat <<EOF > ${NAME}.spec
 %endif
 
 %if 0%{?is_opensuse} && 0%{?suse_version} > 1500
-  %define _base_image tumbleweed
+  %define _base_image kubic
 %endif
 
 Name:           $NAME


### PR DESCRIPTION
After discussion, we collectively decided kubic- makes more sense as the _base_image name for kubic images, even if they're built from Tumbleweed