### PR TITLE
Sync haproxy manifest with salt repo

### DIFF
--- a/manifests/haproxy.yaml
+++ b/manifests/haproxy.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: kube-system
   labels:
     name: haproxy
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ''
 spec:
   restartPolicy: Always
   hostNetwork: true
@@ -13,6 +15,8 @@ spec:
     - key: node-role.kubernetes.io/master
       operator: Exists
       effect: NoSchedule
+    - key: "CriticalAddonsOnly"
+      operator: "Exists"
   containers:
     - name: haproxy
       image: sles12/haproxy:__TAG__


### PR DESCRIPTION
The haproxy manifest is duplicated between the salt and c-c-m repo,
sync the recent changes from the salt repo over here to keep
everything lined up.

Syncs 25c660fd92150fbf8b1a7213282d2f9ead9a67e6 from the salt repo.