### PR TITLE
Move haproxy config to /etc/caasp/haproxy

### DIFF
--- a/manifests/haproxy.yaml
+++ b/manifests/haproxy.yaml
@@ -41,7 +41,7 @@ spec:
   volumes:
     - name: haproxy-cfg
       hostPath:
-        path: /etc/haproxy
+        path: /etc/caasp/haproxy
     - name: etc-hosts
       hostPath:
         path: /etc/hosts

--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -100,7 +100,7 @@ for file in manifests/*.yaml; do
   # fix image name
   sed -e "s|image:[ ]*sles12/\(.*\):|image: %{_base_image}/\1:|g" -i %{buildroot}/%{_datadir}/%{name}/\$file
 done
-install -D -m 0755 config/haproxy/haproxy.cfg %{buildroot}/etc/haproxy/haproxy.cfg
+install -D -m 0755 config/haproxy/haproxy.cfg %{buildroot}/etc/caasp/haproxy/haproxy.cfg
 install -D -m 0755 activate.sh %{buildroot}/%{_datadir}/%{name}/activate.sh
 # fix image name in activate
 sed -e "s|sles12/pause|%{_base_image}/pause|g" -i %{buildroot}/%{_datadir}/%{name}/activate.sh
@@ -136,8 +136,8 @@ ln -s %{_sbindir}/service %{buildroot}/%{_sbindir}/rcadmin-node-setup
 %doc LICENSE README.md
 %dir %{_datadir}/%{name}
 %dir %{_datadir}/%{name}/manifests
-%dir /etc/haproxy
-%config(noreplace) /etc/haproxy/haproxy.cfg
+%dir /etc/caasp/haproxy
+%config(noreplace) /etc/caasp/haproxy/haproxy.cfg
 %{_sbindir}/rcadmin-node-setup
 %{_unitdir}/admin-node-setup.service
 %{_datadir}/%{name}/*


### PR DESCRIPTION
This avoids a conflict between the caasp-container-manifests package,
and the haproxy package.

Depends-On: https://github.com/kubic-project/salt/pull/389