### PR TITLE
Fix spec file

### DIFF
--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -136,6 +136,7 @@ ln -s %{_sbindir}/service %{buildroot}/%{_sbindir}/rcadmin-node-setup
 %doc LICENSE README.md
 %dir %{_datadir}/%{name}
 %dir %{_datadir}/%{name}/manifests
+$dir /etc/caasp
 %dir /etc/caasp/haproxy
 %config(noreplace) /etc/caasp/haproxy/haproxy.cfg
 %{_sbindir}/rcadmin-node-setup


### PR DESCRIPTION
Fix a build error introduced by the previous change:

    [   26s] caasp-container-manifests-3.0.0+git_r240_60aff03-1.1.noarch.rpm: directories not owned by a package:
    [   26s]  - /etc/caasp