### PR TITLE
enable certificate validation for net-ldap

### DIFF
--- a/admin-node-setup.sh
+++ b/admin-node-setup.sh
@@ -61,6 +61,12 @@ fi
 # Generate TLS CA and Initial Certificates
 /usr/share/caasp-container-manifests/gen-certs.sh
 
+# add an entry for ldap.infra.caasp.local to /etc/hosts
+# this is needed to enable net-ldap to validate the certificate for LDAP_HOST
+if ! [ "$(cat /etc/hosts | grep -E "^127.0.0.1\s+" | grep ldap.infra.caasp.local)" ]; then
+    sed -i 's/127.0.0.1\tlocalhost/127.0.0.1\tlocalhost ldap.infra.caasp.local/g' /etc/hosts
+fi
+
 VELUM_CRT_FINGERPRINT_SHA1=$(openssl x509 -noout -in /etc/pki/velum.crt -fingerprint -sha1 | cut -d= -f2)
 VELUM_CRT_FINGERPRINT_SHA256=$(openssl x509 -noout -in /etc/pki/velum.crt -fingerprint -sha256 | cut -d= -f2)
 

--- a/gen-certs.sh
+++ b/gen-certs.sh
@@ -161,4 +161,4 @@ set -e
 genca
 gencert "velum" "Velum" "$all_hostnames" "$(ip_addresses)"
 gencert "salt-api" "salt-api.infra.caasp.local" "" "127.0.0.1"
-gencert "ldap" "OpenLDAP" "$all_hostnames" "$(ip_addresses)"
+gencert "ldap" "OpenLDAP" "ldap.infra.caasp.local" "$(ip_addresses)"

--- a/manifests/public.yaml
+++ b/manifests/public.yaml
@@ -256,7 +256,7 @@ spec:
     - name: VELUM_INTERNAL_API_PASSWORD_FILE
       value: /var/lib/misc/infra-secrets/velum-internal-api-password
     - name: LDAP_HOST
-      value: "127.0.0.1"
+      value: "ldap.infra.caasp.local"
     - name: LDAP_PORT
       value: "389"
     - name: LDAP_GROUP_BASE_DN
@@ -326,7 +326,7 @@ spec:
     - name: VELUM_INTERNAL_API_PASSWORD_FILE
       value: /var/lib/misc/infra-secrets/velum-internal-api-password
     - name: LDAP_HOST
-      value: "127.0.0.1"
+      value: "ldap.infra.caasp.local"
     - name: LDAP_PORT
       value: "389"
     - name: LDAP_GROUP_BASE_DN


### PR DESCRIPTION
CVE-2017-17718 requires net-ldap to validate the certificate

therefore set a fixed resolvable name for ldap and generate
the certificate for it

Signed-off-by: Maximilian Meister <mmeister@suse.de>