### PR TITLE
Increase haproxy timeouts from 50sec, to 120sec

### DIFF
--- a/config/haproxy/haproxy.cfg
+++ b/config/haproxy/haproxy.cfg
@@ -9,8 +9,8 @@ defaults
         option  tcplog
         option  dontlognull
         timeout connect 5000
-        timeout client 50000
-        timeout server 50000
+        timeout client 120000
+        timeout server 120000
 
 listen velum
         bind 0.0.0.0:80


### PR DESCRIPTION
Some components have a 60 second timeout for salt request timeouts, e.g the
salt-api server which is called by Velum. Increase this timeout to double
their timeouts to allow the real failures to be disclosed.

We'll likely want to rework how timeouts are handled soon accross all our
components.