### PR TITLE
Velum Dash and API both attempt to bind to the same port

### DIFF
--- a/config/haproxy/haproxy.cfg
+++ b/config/haproxy/haproxy.cfg
@@ -25,7 +25,7 @@ listen velum
         server velum unix@/var/run/puma/dashboard.sock
 
 listen velum-api
-        bind 127.0.0.1:443 ssl crt /etc/pki/velum.pem ca-file /etc/pki/ca.crt
+        bind 127.0.0.1:444 ssl crt /etc/pki/velum.pem ca-file /etc/pki/ca.crt
         mode http
         option forwardfor
         http-request set-header X-Forwarded-Proto https


### PR DESCRIPTION
It's not possible to reliably bind to 0.0.0.0:443 for one service,
and 127.0.0.1:443 for another service.

As such, we'll move velum-api over to 127.0.0.1:444

Depends-On: https://github.com/kubic-project/salt/pull/394