### PR TITLE
[WIP] Remove VELUM_WORKERS environment variable

### DIFF
--- a/manifests/public.yaml
+++ b/manifests/public.yaml
@@ -233,8 +233,6 @@ spec:
       value: /var/lib/misc/velum-secrets
     - name: VELUM_SOCKET_NAME
       value: dashboard.sock
-    - name: VELUM_WORKERS
-      value: "2"
     - name: VELUM_DB_HOST
       value:
     - name: VELUM_DB_USERNAME
@@ -303,8 +301,6 @@ spec:
       value: /var/lib/misc/velum-secrets
     - name: VELUM_SOCKET_NAME
       value: api.sock
-    - name: VELUM_WORKERS
-      value: "6"
     - name: VELUM_DB_HOST
       value:
     - name: VELUM_DB_USERNAME


### PR DESCRIPTION
Velum had been updated to run more workers, but that didn't take
effect as this was overriding the default.

The default will now be applied - which is 8 workers for both the
dashboard, and api containers.

----

The result of this will be more memory used... are we OK with that?