### PR TITLE
Update missed LDAP_HOST value from 127.0.0.1 to ldap.infra.caasp.local

### DIFF
--- a/manifests/public.yaml
+++ b/manifests/public.yaml
@@ -422,7 +422,7 @@ spec:
     - name: VELUM_INTERNAL_API_PASSWORD_FILE
       value: /var/lib/misc/infra-secrets/velum-internal-api-password
     - name: LDAP_HOST
-      value: "127.0.0.1"
+      value: "ldap.infra.caasp.local"
     - name: LDAP_PORT
       value: "389"
     - name: LDAP_GROUP_BASE_DN


### PR DESCRIPTION
I don't think this value is actually used, however, for consistency, lets set it
to the correct value. We may want to check if it's used and remove if not.