### PR TITLE
Haproxy: Mount config dir as read only

### DIFF
--- a/manifests/haproxy.yaml
+++ b/manifests/haproxy.yaml
@@ -28,6 +28,7 @@ spec:
       volumeMounts:
         - name: haproxy-cfg
           mountPath: /etc/haproxy
+          readOnly: True
         - name: etc-hosts
           mountPath: /etc/hosts
         - name: velum-bundle-certificate


### PR DESCRIPTION
There is no good reason for this container to be modifying anything in
/etc/haproxy (or /etc/caasp/haproxy as seen on the host). Remove it's
ability to do so.