### PR TITLE
Remove Kubic workaround, caasp-tools no longer conflicts

### DIFF
--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -78,12 +78,6 @@ Requires:       %{_base_image}-caasp-dex-image >= 2.0.0
 Requires:       kubernetes-salt
 BuildArch:      noarch
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
-%if ! 0%{?is_susecaasp}
-# caasp-tools package provides %{_datadir}/caasp-container-manifests/activate.sh
-# if this is not building for SUSE CaaSP, so both packages can't be installed
-# at the same time.
-Conflicts:      caasp-tools
-%endif
 
 %description
 Manifest file templates will instruct kubelet service to bring up salt


### PR DESCRIPTION
Urgent - there is a mismatch between what is in our git repo and what is in OBS - this resolves that.

Any caasp-container-manifests submissions before this gets submitted to Factory risk breaking Kubic