### PR TITLE
Update manifests to match haproxy changes to work as an http proxy

### DIFF
--- a/admin-node-setup.sh
+++ b/admin-node-setup.sh
@@ -72,7 +72,7 @@ if [[ ! -f "/etc/caasp/haproxy/haproxy.cfg" && -f "/etc/haproxy/haproxy.cfg" ]];
 
 listen velum
         bind 0.0.0.0:80
-        bind 0.0.0.0:443 ssl crt /etc/pki/velum.pem ca-file /etc/pki/ca.crt
+        bind 0.0.0.0:443 ssl crt /etc/pki/private/velum-bundle.pem ca-file /etc/pki/ca.crt
         mode http
         acl path_autoyast path_reg ^/autoyast$
         option forwardfor
@@ -83,7 +83,7 @@ listen velum
         server velum unix@/var/run/puma/dashboard.sock
 
 listen velum-api
-        bind 127.0.0.1:443 ssl crt /etc/pki/velum.pem ca-file /etc/pki/ca.crt
+        bind 127.0.0.1:443 ssl crt /etc/pki/private/velum-bundle.pem ca-file /etc/pki/ca.crt
         mode http
         option forwardfor
         http-request set-header X-Forwarded-Proto https

--- a/config/haproxy/haproxy.cfg
+++ b/config/haproxy/haproxy.cfg
@@ -13,7 +13,7 @@ defaults
 
 listen velum
         bind 0.0.0.0:80
-        bind 0.0.0.0:443 ssl crt /etc/pki/velum.pem ca-file /etc/pki/ca.crt
+        bind 0.0.0.0:443 ssl crt /etc/pki/private/velum-bundle.pem ca-file /etc/pki/ca.crt
         mode http
         acl path_autoyast path_reg ^/autoyast$
         option forwardfor
@@ -24,7 +24,7 @@ listen velum
         server velum unix@/var/run/puma/dashboard.sock
 
 listen velum-api
-        bind 127.0.0.1:444 ssl crt /etc/pki/velum.pem ca-file /etc/pki/ca.crt
+        bind 127.0.0.1:444 ssl crt /etc/pki/private/velum-bundle.pem ca-file /etc/pki/ca.crt
         mode http
         option forwardfor
         http-request set-header X-Forwarded-Proto https

--- a/manifests/haproxy.yaml
+++ b/manifests/haproxy.yaml
@@ -28,13 +28,16 @@ spec:
       volumeMounts:
         - name: haproxy-cfg
           mountPath: /etc/haproxy
+        - name: ca-certificate
+          mountPath: /etc/pki/ca.crt
+          readOnly: True
+        - name: kubernetes-proxy-bundle-certificate
+          mountPath: /etc/pki/private/kube-apiserver-proxy-bundle.pem
+          readOnly: True
         - name: etc-hosts
           mountPath: /etc/hosts
         - name: velum-bundle-certificate
-          mountPath: /etc/pki/velum.pem
-          readOnly: True
-        - name: ca-certificate
-          mountPath: /etc/pki/ca.crt
+          mountPath: /etc/pki/private/velum-bundle.pem
           readOnly: True
         - name: velum-unix-socket
           mountPath: /var/run/puma
@@ -42,15 +45,20 @@ spec:
     - name: haproxy-cfg
       hostPath:
         path: /etc/caasp/haproxy
+    - name: ca-certificate
+      hostPath:
+        path: /etc/pki/ca.crt
+        type: FileOrCreate
+    - name: kubernetes-proxy-bundle-certificate
+      hostPath:
+        path: /etc/pki/private/kube-apiserver-proxy-bundle.pem
+        type: FileOrCreate
     - name: etc-hosts
       hostPath:
         path: /etc/hosts
     - name: velum-bundle-certificate
       hostPath:
         path: /etc/pki/private/velum-bundle.pem
-    - name: ca-certificate
-      hostPath:
-        path: /etc/pki/ca.crt
     - name: velum-unix-socket
       hostPath:
         path: /var/run/puma


### PR DESCRIPTION
Required changes to make the config that will be copied by `admin-node-setup.sh` script match with the manifest deployed by salt.

We really need a different approach here for the near future.