### PR TITLE
Pass through /etc/caasp/pillar-seeds to Velum Dashboard container

### DIFF
--- a/manifests/public.yaml
+++ b/manifests/public.yaml
@@ -295,6 +295,9 @@ spec:
       readOnly: True
     - mountPath: /etc/caasp/cpi
       name: caasp-cpi-configs
+    - mountPath: /etc/caasp/pillar-seeds
+      name: caasp-pillar-seeds
+      readOnly: True
     args: ["bin/init"]
   - name: velum-api
     image: sles12/velum:__TAG__
@@ -558,3 +561,6 @@ spec:
   - name: caasp-cpi-configs
     hostPath:
       path: /etc/caasp/cpi
+  - name: caasp-pillar-seeds
+    hostPath:
+      path: /etc/caasp/pillar-seeds


### PR DESCRIPTION
This allows for pre-seeding any pillar values specified in the above
directory.

feature#hide-openstack-cpi

Related to https://github.com/kubic-project/velum/pull/492
Related to https://build.suse.de/request/show/161767