### PR TITLE
mount cloud pillar in salt-master cotainer

### DIFF
--- a/public.yaml
+++ b/public.yaml
@@ -146,6 +146,9 @@ spec:
     - mountPath: /var/lib/misc/infra-secrets
       name: infra-secrets
       readOnly: True
+    - mountPath: /srv/pillar
+      name: public-cloud-config
+      readOnly: True
   - name: salt-api
     image: sles12/salt-api:__TAG__
     volumeMounts:
@@ -483,3 +486,6 @@ spec:
   - name: infra-secrets
     hostPath:
       path: /var/lib/misc/infra-secrets
+  - name: public-cloud-config
+    hostPath:
+      path: /etc/salt/pillar


### PR DESCRIPTION
This is required to give the salt-master access to static cloud-specific pillar data.