### PR TITLE
Run activate.sh from admin-node-init.service during the first boot

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -3,6 +3,11 @@
 # this script WILL BE RUN ONLY ONCE, after the installation
 # this script WILL NOT RUN during/after upgrades
 
+DIDRUNFILE=/var/lib/misc/caasp-admin-node-init-did-run
+
+# Don't run this script a second time
+test -f ${DIDRUNFILE}  && exit 0
+
 # Make sure that the controller node looks for the local pause image
 # TODO: remove this as soon as possible. As an idea, we could use a systemd drop-in unit.
 if ! grep "pod-infra-container-image" /etc/kubernetes/kubelet &> /dev/null; then
@@ -32,3 +37,6 @@ echo "id: admin" > /etc/salt/minion.d/minion_id.conf
 # Disable swap
 # On ISO-based installs the script runs in a chroot and then the system is rebooted
 sed -i '/^#/! {/ swap / s/^/#/}' /etc/fstab
+
+# Mark that the script did run
+touch ${DIDRUNFILE}

--- a/admin-node-init.service
+++ b/admin-node-init.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Initialize Administration Node
+Conflicts=shutdown.target
+After=local-fs.target
+Before=admin-node-setup.service
+ConditionPathExists=!/var/lib/misc/caasp-admin-node-init-did-run
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=__ADMIN_NODE_SETUP_PATH__/activate.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -114,20 +114,22 @@ install -D -m 0755 admin-node-setup.sh %{buildroot}/%{_datadir}/%{name}/admin-no
 mkdir -p %{buildroot}/%{_unitdir}
 install -D -m 0644 admin-node-setup.service %{buildroot}/%{_unitdir}/
 sed -e "s#__ADMIN_NODE_SETUP_PATH__#%{_datadir}/%{name}#" -i %{buildroot}/%{_unitdir}/admin-node-setup.service
+install -D -m 0644 admin-node-init.service %{buildroot}/%{_unitdir}/
+sed -e "s#__ADMIN_NODE_SETUP_PATH__#%{_datadir}/%{name}#" -i %{buildroot}/%{_unitdir}/admin-node-init.service
 mkdir -p %{buildroot}/%{_sbindir}
 ln -s %{_sbindir}/service %{buildroot}/%{_sbindir}/rcadmin-node-setup
 
 %pre
-%service_add_pre admin-node-setup.service
+%service_add_pre admin-node-setup.service admin-node-init.service
 
 %post
-%service_add_post admin-node-setup.service
+%service_add_post admin-node-setup.service admin-node-init.service
 
 %preun
-%service_del_preun admin-node-setup.service
+%service_del_preun admin-node-setup.service admin-node-init.service
 
 %postun
-%service_del_postun admin-node-setup.service
+%service_del_postun admin-node-setup.service admin-node-init.service
 
 %files
 %defattr(-,root,root)
@@ -138,6 +140,7 @@ $dir /etc/caasp
 %dir /etc/caasp/haproxy
 %config(noreplace) /etc/caasp/haproxy/haproxy.cfg
 %{_sbindir}/rcadmin-node-setup
+%{_unitdir}/admin-node-init.service
 %{_unitdir}/admin-node-setup.service
 %{_datadir}/%{name}/*
 %changelog


### PR DESCRIPTION
Currently we have a special YaST module to run active.sh after installation. To make things easier and to unify our configuration processes, I propose to run the script by a systemd service once at the first boot.
This solution is compatible with the current SLE12 based code as with the new Factory/SLE15 code.