### PR TITLE
[WIP] drop MySQLdb specific env

### DIFF
--- a/manifests/public.yaml
+++ b/manifests/public.yaml
@@ -119,8 +119,6 @@ spec:
   - name: salt-master
     image: sles12/salt-master:__TAG__
     env:
-    - name: MYSQL_UNIX_PORT
-      value: /var/run/mysql/mysql.sock
     - name: SALTAPI_PASSWORD_FILE
       value: /var/lib/misc/infra-secrets/saltapi-password
     - name: VELUM_INTERNAL_API_USERNAME_FILE


### PR DESCRIPTION
this only affects kubic for now where we use PyMySQL instead of
MySQLdb

salt#mysql-unix-socket

Signed-off-by: Maximilian Meister <mmeister@suse.de>

## not to be merged yet

### depends on
switch to salt `2018.3` and therefore switch to `PyMySQL`