### PR TITLE
[WIP] Restrict read access in the LDAP database

### DIFF
--- a/config/ldap/ldap.conf
+++ b/config/ldap/ldap.conf
@@ -1,0 +1,18 @@
+#
+# LDAP Defaults
+#
+
+# See ldap.conf(5) for details
+# This file should be world readable but not world writable.
+
+#BASE	dc=example,dc=com
+#URI	ldap://ldap.example.com ldap://ldap-master.example.com:666
+
+#SIZELIMIT	12
+#TIMELIMIT	15
+#DEREF		never
+
+BASE             ou=Groups,dc=infra,dc=caasp,dc=local
+HOST             admin.infra.caasp.local
+TLS_CACERT       /etc/openldap/pki/ca.crt
+TLS_REQCERT      allow

--- a/config/ldap/slapd.conf
+++ b/config/ldap/slapd.conf
@@ -1,0 +1,89 @@
+###########################################################
+# CaaSP: this file will be mounted on the ldap
+#        container as /etc/openldap/slapd.conf.template,
+#        then the entrypoint.sh will replace some things
+#        (marked with REPLACED_BY_THE_CONTAINER_ENTRYPOINT)
+###########################################################
+
+#
+# See slapd.conf(5) for details on configuration options.
+# This file should NOT be world readable.
+#
+include		/etc/openldap/schema/core.schema
+include		/etc/openldap/schema/cosine.schema
+include		/etc/openldap/schema/inetorgperson.schema
+include		/etc/openldap/schema/rfc2307bis.schema
+include		/etc/openldap/schema/yast.schema
+
+# Define global ACLs to disable default read access.
+
+# Do not enable referrals until AFTER you have a working directory
+# service AND an understanding of referrals.
+#referral	ldap://root.openldap.org
+
+pidfile		/run/slapd/slapd.pid
+argsfile	/run/slapd/slapd.args
+
+# Load dynamic backend modules:
+# modulepath	/usr/lib/openldap/modules
+# moduleload	back_bdb.la
+# moduleload	back_hdb.la
+# moduleload	back_ldap.la
+
+# Sample security restrictions
+#	Require integrity protection (prevent hijacking)
+#	Require 112-bit (3DES or better) encryption for updates
+#	Require 63-bit encryption for simple bind
+# security ssf=1 update_ssf=112 simple_bind=64
+
+# Access control policy:
+#
+#       Root DSE: allow anyone to read it
+#       Subschema (sub)entry DSE: allow anyone to read it
+
+access to dn.base="" by * read
+access to dn.base="cn=Subschema" by * read
+
+# Allow self write access to user password
+# Allow anonymous users to authenticate
+# Allow anyone to read the last password change
+
+access to attrs=userPassword,userPKCS12
+       by self write
+       by * auth
+
+access to attrs=shadowLastChange
+       by self write
+       by * read
+
+# block everything else
+access to * by * none
+
+# if no access controls are present, the default policy
+# allows anyone and everyone to read anything but restricts
+# updates to rootdn.  (e.g., "access to * by * read")
+#
+# rootdn can always read and write EVERYTHING!
+
+#######################################################################
+# BDB database definitions
+#######################################################################
+
+database        bdb
+suffix          REPLACED_BY_THE_CONTAINER_ENTRYPOINT
+checkpoint      1024    5
+cachesize       10000
+rootdn          REPLACED_BY_THE_CONTAINER_ENTRYPOINT
+
+# Cleartext passwords, especially for the rootdn, should
+# be avoid.  See slappasswd(8) and slapd.conf(5) for details.
+# Use of strong authentication encouraged.
+rootpw          REPLACED_BY_THE_CONTAINER_ENTRYPOINT
+
+# The database directory MUST exist prior to running slapd AND
+# should only be accessible by the slapd and slap tools.
+# Mode 700 recommended.
+directory      /var/lib/ldap
+
+# Indices to maintain
+index          objectClass    eq

--- a/manifests/public.yaml
+++ b/manifests/public.yaml
@@ -389,7 +389,19 @@ spec:
       value: "true"
     - name: SLAPD_PASSWORD_FILE
       value: /var/lib/misc/infra-secrets/openldap-password
+    - name: SLAPD_CONF_TEMPLATE
+      value: /etc/openldap/slapd.conf.default
+    - name: LDAP_CONF_TEMPLATE
+      value: /etc/openldap/ldap.conf.default
     volumeMounts:
+    # slapd.conf.default is copied to slapd.conf by the container entrypoint
+    - mountPath: /etc/openldap/slapd.conf.default
+      name: slapd-conf
+      readOnly: True
+    # same for ldap.conf.default
+    - mountPath: /etc/openldap/ldap.conf.default
+      name: ldap-conf
+      readOnly: True
     - mountPath: /etc/openldap/pki/openldap.crt
       name: openldap-certificate
       readOnly: True
@@ -529,6 +541,12 @@ spec:
   - name: salt-minion-ca-certificates
     hostPath:
       path: /etc/pki
+  - name: ldap-conf
+    hostPath:
+      path: /usr/share/caasp-container-manifests/config/ldap/ldap.conf
+  - name: slapd-conf
+    hostPath:
+      path: /usr/share/caasp-container-manifests/config/ldap/slapd.conf
   - name: openldap-certificate
     hostPath:
       path: /etc/pki/ldap.crt

--- a/manifests/public.yaml
+++ b/manifests/public.yaml
@@ -57,7 +57,7 @@ spec:
   - name: salt-minion-key-generation
     image: sles12/salt-master:__TAG__
     command: ["sh", "-c", "umask 377;
-                           mkdir /salt-master-pki/minions/;
+                           mkdir -p /salt-master-pki/minions/;
                            temp_dir=`mktemp -d`;
                            if [ -f /salt-admin-minion-pki/minion.pub ] && [ -f /salt-admin-minion-pki/minion.pem ] && [ ! -f /salt-master-pki/minions/admin ]; then
                              cp /salt-admin-minion-pki/minion.pub /salt-master-pki/minions/admin;
@@ -71,7 +71,7 @@ spec:
                            if [ -f /salt-ca-minion-pki/minion.pub ] && [ -f /salt-ca-minion-pki/minion.pem ] && [ ! -f /salt-master-pki/minions/ca ]; then
                              cp /salt-ca-minion-pki/minion.pub /salt-master-pki/minions/ca;
                            fi;
-                           if [ ! -f /salt-ca-minion-pki/minion.pub ] || [ ! -f /tmp/ca.pem /salt-ca-minion-pki/minion.pem ]; then
+                           if [ ! -f /salt-ca-minion-pki/minion.pub ] || [ ! -f /tmp/ca.pem ] || [ ! -f /salt-ca-minion-pki/minion.pem ]; then
                              salt-key -u root --gen-keys=ca --gen-keys-dir $temp_dir;
                              cp $temp_dir/ca.pub /salt-master-pki/minions/ca;
                              mv $temp_dir/ca.pub /salt-ca-minion-pki/minion.pub;
@@ -89,8 +89,8 @@ spec:
   - name: salt-master-config
     image: sles12/velum:__TAG__
     command: ["sh", "-c", "umask 377;
-                           rmdir /salt-master-credentials/55-returner-credentials.conf;
-                           if ! grep mysql /salt-master-credentials/55-returner-credentials.conf; then
+                           [ -d /salt-master-credentials/55-returner-credentials.conf ] && rmdir /salt-master-credentials/55-returner-credentials.conf;
+                           if ! grep -q mysql /salt-master-credentials/55-returner-credentials.conf; then
                              echo \"mysql:\" > /salt-master-credentials/55-returner-credentials.conf;
                              echo -n \"  pass: \" >> /salt-master-credentials/55-returner-credentials.conf;
                              cat /infra-secrets/mariadb-salt-password >> /salt-master-credentials/55-returner-credentials.conf;


### PR DESCRIPTION
Do not allow read access without authentication for all the attributes in the LDAP server.

See [Trello issue](https://trello.com/c/q5cr4yp1/871-bug-1092495-ldapsearch-without-authentication-allows-listing-all-objects-and-attributes).
See [bugzilla issue](https://bugzilla.suse.com/show_bug.cgi?id=1092495).

bsc#1092495