### PR TITLE
fix image name for CaaSP4

### DIFF
--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -42,7 +42,7 @@ cat <<EOF > ${NAME}.spec
 %endif
 
 %if 0%{?suse_version} == 1500 && !0%{?is_opensuse}
-  %define _base_image sles15
+  %define _base_image caasp
 %endif
 
 %if 0%{?is_opensuse} && 0%{?suse_version} > 1500

--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -60,7 +60,7 @@ Source:         ${SAFE_BRANCH}.tar.gz
 
 # If it is not SLE15, require container-feeder
 # Otherwise, we are using the SUSE Registry
-%if 0%{?sle_version} != 150000
+%if 0%{?sle_version} < 150000
 Requires:       container-feeder
 %endif
 

--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -64,22 +64,6 @@ Source:         ${SAFE_BRANCH}.tar.gz
 Requires:       container-feeder
 %endif
 
-# Require all the docker images
-Requires:       %{_base_image}-pause-image >= 2.0.0
-Requires:       %{_base_image}-mariadb-image >= 2.0.0
-Requires:       %{_base_image}-pv-recycler-node-image >= 2.0.0
-Requires:       %{_base_image}-salt-api-image >= 2.0.0
-Requires:       %{_base_image}-salt-master-image >= 2.0.0
-Requires:       %{_base_image}-salt-minion-image >= 2.0.0
-Requires:       %{_base_image}-velum-image >= 2.0.0
-Requires:       %{_base_image}-haproxy-image >= 2.0.0
-Requires:       %{_base_image}-flannel-image >= 2.0.0
-Requires:       %{_base_image}-dnsmasq-nanny-image >= 2.0.0
-Requires:       %{_base_image}-kubedns-image >= 2.0.0
-Requires:       %{_base_image}-sidecar-image >= 2.0.0
-Requires:       %{_base_image}-tiller-image >= 2.0.0
-Requires:       %{_base_image}-openldap-image >= 2.0.0
-Requires:       %{_base_image}-caasp-dex-image >= 2.0.0
 # Require all  the things we mount from the host from the kubernetes-salt package
 Requires:       kubernetes-salt
 BuildArch:      noarch


### PR DESCRIPTION
We have changed the naming of the images. Instead of calling them
sleXY/image_name, we call them caasp/image_name, so we don't have to
create a new package each time we change the base image.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>