### PR TITLE
Configure `innodb_log_file_size` to a 128M limit

### DIFF
--- a/config/mysql/max-allowed-packet.cnf
+++ b/config/mysql/max-allowed-packet.cnf
@@ -1,2 +1,0 @@
-[mysqld]
-max_allowed_packet=16M

--- a/config/mysql/skip-networking.cnf
+++ b/config/mysql/skip-networking.cnf
@@ -1,2 +1,0 @@
-[mysqld]
-skip-networking

--- a/manifests/private.yaml
+++ b/manifests/private.yaml
@@ -38,17 +38,13 @@ spec:
       value: "true"
     - name: MYSQL_ROOT_PASSWORD_FILE
       value: /var/lib/misc/infra-secrets/mariadb-root-password
+    - name: MYSQLD_CONFIG
+      value: "skip-networking;max_allowed_packet=16M;innodb_log_file_size=128M"
     volumeMounts:
     - mountPath: /var/lib/mysql
       name: mariadb-data
     - mountPath: /var/run/mysql
       name: mariadb-unix-socket
-    - mountPath: /etc/my.cnf.d/skip-networking.cnf
-      name: mariadb-config-skip-networking
-      readOnly: True
-    - mountPath: /etc/my.cnf.d/max-allowed-packet.cnf
-      name: mariadb-config-max-allowed-packet
-      readOnly: True
     - mountPath: /var/lib/misc/infra-secrets
       name: infra-secrets
       readOnly: True
@@ -59,12 +55,6 @@ spec:
   - name: mariadb-unix-socket
     hostPath:
       path: /var/run/mysql
-  - name: mariadb-config-skip-networking
-    hostPath:
-      path: /usr/share/caasp-container-manifests/config/mysql/skip-networking.cnf
-  - name: mariadb-config-max-allowed-packet
-    hostPath:
-      path: /usr/share/caasp-container-manifests/config/mysql/max-allowed-packet.cnf
   - name: infra-secrets
     hostPath:
       path: /var/lib/misc/infra-secrets


### PR DESCRIPTION
When a salt output is big enough, mysql will refuse to insert the offending
row for being too big, with an error:

```
[ERROR   ] Could not store events - returner 'mysql.event_return' raised exception:
(1118, 'The size of BLOB/TEXT data inserted in one transaction is greater than 10% of redo log size.
Increase the redo log size using innodb_log_file_size.')
```

Whatever we set as `innodb_log_file_size` will be an arbitrary number that will
eventually be flooded if the cluster is big enough, or if salt is noisy enough.
Given a cluster size, this can suddenly fail if we add more states (thus, increasing
salt's output). Obviously, given the same salt states, we can also reach this limit
by increasing the cluster size.

There is not a definitive fix for this issue, all we can do for now (without a proper
refactor of the way we integrate salt and velum) is to ensure that with todays salt
states we can reach a certain number of nodes. As said, this can no longer be true if
we add more salt states and we reach again the limit for the same cluster size.

Fixes: bsc#1095335

Depends on: https://github.com/kubic-project/container-images/pull/31