### PR TITLE
Fix bsc#1072242: Map the keyboard file into velum container.

### DIFF
--- a/manifests/public.yaml
+++ b/manifests/public.yaml
@@ -318,6 +318,9 @@ spec:
     - mountPath: /srv/velum/public/favicon.ico
       name: velum-icon
       readOnly: True
+    - mountPath: /var/lib/misc/keyboard
+      name: yast-keyboard-configuration
+      readOnly: True
     args: ["bin/run"]
   - name: velum-api
     image: sles12/velum:__TAG__
@@ -595,3 +598,6 @@ spec:
   - name: velum-icon
     hostPath:
       path: /usr/share/velum/images/favicon.ico
+  - name: yast-keyboard-configuration
+    hostPath:
+      path: /etc/sysconfig/keyboard


### PR DESCRIPTION
Map the keyboard file from the admin node into the valum container to make
keyboard defined in YaST available.

Signed-off-by: Florian Bergmann <fbergmann@suse.de>