### PR TITLE
Do not mount the public directory or the compiled assets get hidden in

### DIFF
--- a/manifests/public.yaml
+++ b/manifests/public.yaml
@@ -589,9 +589,6 @@ spec:
   - name: velum-dist-name
     hostPath:
       path: /usr/share/velum/PRODUCT
-  - name: velum-static-pages
-    hostPath:
-      path: /usr/share/velum/public
   - name: velum-images
     hostPath:
       path: /usr/share/velum/images

--- a/manifests/public.yaml
+++ b/manifests/public.yaml
@@ -312,9 +312,6 @@ spec:
     - mountPath: /srv/velum/PRODUCT
       name: velum-dist-name
       readOnly: True
-    - mountPath: /srv/velum/public
-      name: velum-static-pages
-      readOnly: True
     - mountPath: /srv/velum/public/branding
       name: velum-images
       readOnly: True

--- a/manifests/public.yaml
+++ b/manifests/public.yaml
@@ -313,7 +313,10 @@ spec:
       name: velum-dist-name
       readOnly: True
     - mountPath: /srv/velum/public/branding
-      name: velum-images
+      name: velum-branding
+      readOnly: True
+    - mountPath: /srv/velum/public/favicon.ico
+      name: velum-icon
       readOnly: True
     args: ["bin/run"]
   - name: velum-api
@@ -586,6 +589,9 @@ spec:
   - name: velum-dist-name
     hostPath:
       path: /usr/share/velum/PRODUCT
-  - name: velum-images
+  - name: velum-branding
     hostPath:
       path: /usr/share/velum/images
+  - name: velum-icon
+    hostPath:
+      path: /usr/share/velum/images/favicon.ico

--- a/manifests/public.yaml
+++ b/manifests/public.yaml
@@ -315,7 +315,7 @@ spec:
     - mountPath: /srv/velum/public
       name: velum-static-pages
       readOnly: True
-    - mountPath: /srv/velum/app/assets/images
+    - mountPath: /srv/velum/public/branding
       name: velum-images
       readOnly: True
     args: ["bin/run"]


### PR DESCRIPTION
the iso

Mounting the public directory from the host, was "hidding" the assets
files present in the public directory and so our images were broken.

This was only happening in the iso and not in our dev environments
because in production we have the assets precompiled and we don't
compile them on the fly, since we don't have a js engine installed.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>