### PR TITLE
We removed the mysql dir, so we need to do the same in the package

### DIFF
--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -103,7 +103,7 @@ sed -e "s|sles12/pause|%{_base_image}/pause|g" -i %{buildroot}/%{_datadir}/%{nam
 sed -e "s|pause:1.0.0|pause:0.1|g" -i %{buildroot}/%{_datadir}/%{name}/activate.sh
 %endif
 install -D -m 0755 gen-certs.sh %{buildroot}/%{_datadir}/%{name}/gen-certs.sh
-for dir in mysql salt/grains salt/minion.d-ca; do
+for dir in salt/grains salt/minion.d-ca; do
   install -d %{buildroot}/%{_datadir}/%{name}/config/\$dir
   install config/\$dir/* %{buildroot}/%{_datadir}/%{name}/config/\$dir
 done


### PR DESCRIPTION
msyql dir was removed in
https://github.com/kubic-project/caasp-container-manifests/pull/189

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>
(cherry picked from commit a392f5c81a3ac046a19e71433cba78ccac381d8c)