### PR TITLE
[3.0] Fix bsc#1072242: Map the keyboard file into velum container.

### DIFF
--- a/manifests/public.yaml
+++ b/manifests/public.yaml
@@ -309,6 +309,9 @@ spec:
     - mountPath: /etc/caasp/pillar-seeds
       name: caasp-pillar-seeds
       readOnly: True
+    - mountPath: /var/lib/misc/keyboard
+      name: yast-keyboard-configuration
+      readOnly: True
     args: ["bin/run"]
   - name: velum-api
     image: sles12/velum:__TAG__
@@ -577,3 +580,6 @@ spec:
   - name: caasp-pillar-seeds
     hostPath:
       path: /etc/caasp/pillar-seeds
+  - name: yast-keyboard-configuration
+    hostPath:
+      path: /etc/sysconfig/keyboard


### PR DESCRIPTION
Map the keyboard file from the admin node into the valum container to make
keyboard defined in YaST available.

Signed-off-by: Florian Bergmann <fbergmann@suse.de>
(cherry picked from commit fda5fa463a34d67b8e7d2686ac8790514e101e4c)

Backport of https://github.com/kubic-project/caasp-container-manifests/pull/191