### PR TITLE
drop branding mount for images

### DIFF
--- a/manifests/public.yaml
+++ b/manifests/public.yaml
@@ -312,9 +312,6 @@ spec:
     - mountPath: /srv/velum/PRODUCT
       name: velum-dist-name
       readOnly: True
-    - mountPath: /srv/velum/public/branding
-      name: velum-branding
-      readOnly: True
     - mountPath: /srv/velum/public/favicon.ico
       name: velum-icon
       readOnly: True
@@ -592,9 +589,6 @@ spec:
   - name: velum-dist-name
     hostPath:
       path: /usr/share/velum/PRODUCT
-  - name: velum-branding
-    hostPath:
-      path: /usr/share/velum/images
   - name: velum-icon
     hostPath:
       path: /usr/share/velum/images/favicon.ico


### PR DESCRIPTION
the images have to be precompiled into the velum rpm, therefore
a mount is useless

velum#branding

Signed-off-by: Maximilian Meister <mmeister@suse.de>