### PR TITLE
Use random CA serial numbers

### DIFF
--- a/gen-certs.sh
+++ b/gen-certs.sh
@@ -9,10 +9,15 @@ CITY=${CITY:-Nuremberg}
 STATE=${STATE:-Bavaria}
 COUNTRY=${COUNTRY:-DE}
 
-DIR="/etc/pki"
+DIR="${DIR:-/etc/pki}"
 CERTS="$DIR/_certs"
 PRIVATEDIR="$DIR/private"
 WORK="$DIR/_work"
+
+
+random_serial() {
+    xxd -l 16 -p /dev/random
+}
 
 genca() {
     [ -f $PRIVATEDIR/ca.key ] && [ -f $DIR/ca.crt ] && return
@@ -85,11 +90,16 @@ basicConstraints = critical, CA:FALSE
 keyUsage = critical, nonRepudiation, digitalSignature, keyEncipherment
 EOF
 
+    random_serial > $WORK/serial
+
     rm -f $WORK/index.txt $WORK/index.txt.attr
     touch $WORK/index.txt $WORK/index.txt.attr
-    echo 1000 > $WORK/serial
 
-    openssl req -batch -config $WORK/ca.cfg -sha256 -new -x509 -days 3650 -extensions v3_ca -key $PRIVATEDIR/ca.key -out $DIR/ca.crt
+    openssl req -batch -config $WORK/ca.cfg \
+                -sha256 -new -x509 -days 3650 \
+                -extensions v3_ca \
+                -key $PRIVATEDIR/ca.key \
+                -out $DIR/ca.crt
 }
 
 gencert() {


### PR DESCRIPTION
We should generate a random CA serial number. According to the CA/Browser Forum Baseline Requirements section 7.1: _"CAs SHOULD generate non‐sequential Certificate serial numbers that exhibit
at least 20 bits of entropy."_. In general it is considered a good practice to use a random number instead of a constant...

feature#security