### PR TITLE
Fix bsc#1099045 adds annotation to use docker/default seccomp profile

### DIFF
--- a/manifests/haproxy.yaml
+++ b/manifests/haproxy.yaml
@@ -8,6 +8,7 @@ metadata:
     name: haproxy
   annotations:
     scheduler.alpha.kubernetes.io/critical-pod: ''
+    seccomp.security.alpha.kubernetes.io/pod: docker/default
 spec:
   restartPolicy: Always
   hostNetwork: true


### PR DESCRIPTION
This annotation will make haproxy use the docker/default seccomp profile.

Signed-off-by: Vicente Zepeda Mas <vzepedamas@suse.com>