### PR TITLE
use the sles12 images from registry.suse.de

### DIFF
--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -42,7 +42,8 @@ cat <<EOF > ${NAME}.spec
 %endif
 
 %if 0%{?suse_version} == 1500 && !0%{?is_opensuse}
-  %define _base_image caasp
+  # Use the sles12 images from the registry
+  %define _base_image registry.suse.de/devel/casp/head/controllernode/images_container_base/sles12
 %endif
 
 %if 0%{?is_opensuse} && 0%{?suse_version} > 1500


### PR DESCRIPTION
This is a first step towards using the registry.
We will use an internal one in registry.suse.de
Later, we will use the registry.suse.com for caasp and
registry.opensuse.org for kubic, however, we have to figure out the
tagging strategy if we want to use kubic images or images based on
sle15.

Thus, for now, we start using the sles12 images which have a fixed tag.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>