### PR TITLE
Use 3.0 images instead of head images

### DIFF
--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -43,7 +43,7 @@ cat <<EOF > ${NAME}.spec
 
 %if 0%{?suse_version} == 1500 && !0%{?is_opensuse}
   # Use the sles12 images from the registry
-  %define _base_image registry.suse.de/devel/casp/head/controllernode/images_container_base/sles12
+  %define _base_image registry.suse.de/devel/casp/3.0/controllernode/images_container_base/sles12
 %endif
 
 %if 0%{?is_opensuse} && 0%{?suse_version} > 1500


### PR DESCRIPTION
Because the images from head will be removed to avoid duplications. The ones
we are using is the ones from 3.0 project, cause those ones cannot be
removed.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>