### PR TITLE
Store the registry configuration as part of the manifests.

### DIFF
--- a/config/registry/registry-config.yaml
+++ b/config/registry/registry-config.yaml
@@ -1,0 +1,10 @@
+# This file defines whether to use container-feeder packaged images or a
+# registry.
+#
+# If use_registry is set to false, the system should use container-feeder images
+# and ignore the host and namespace.
+#
+# namespace: denotes the root namespace under which all images can be found.
+use_registry: false
+host: registry.suse.de
+namespace: devel/casp/3.0/controllernode/images_container_base/sles12

--- a/manifests/public.yaml
+++ b/manifests/public.yaml
@@ -198,6 +198,11 @@ spec:
     - mountPath: /srv/pillar
       name: public-cloud-config
       readOnly: True
+    # This mount path must match the file location on the physical nodes or the salt module
+    # would break either in the container or the physical nodes.
+    - mountPath: /usr/share/caasp-container-manifests/config/registry/registry-config.yaml
+      name: registry-config
+      readOnly: True
   - name: salt-api
     image: sles12/salt-api:__TAG__
     volumeMounts:
@@ -235,6 +240,11 @@ spec:
       readOnly: True
     - mountPath: /etc/salt/pki/minion
       name: salt-ca-minion-pki
+    # This mount path must match the file location on the physical nodes or the salt module
+    # would break either in the container or the physical nodes.
+    - mountPath: /usr/share/caasp-container-manifests/config/registry/registry-config.yaml
+      name: registry-config
+      readOnly: True
   - name: velum-dashboard
     image: sles12/velum:__TAG__
     env:
@@ -595,3 +605,6 @@ spec:
   - name: yast-keyboard-configuration
     hostPath:
       path: /etc/sysconfig/keyboard
+  - name: registry-config
+    hostPath:
+      path: /usr/share/caasp-container-manifests/config/registry/registry-config.yaml

--- a/packaging/suse/0001-patch-in-version-numbers-for-images.patch
+++ b/packaging/suse/0001-patch-in-version-numbers-for-images.patch
@@ -1,0 +1,179 @@
+From d9a6768a28becc3fc951bbd3c06ff01d8632535c Mon Sep 17 00:00:00 2001
+From: Florian Bergmann <fbergmann@suse.de>
+Date: Fri, 12 Oct 2018 17:27:28 +0200
+Subject: [PATCH] patch in version numbers for images
+
+---
+ manifests/haproxy.yaml |  2 +-
+ manifests/private.yaml |  4 ++--
+ manifests/public.yaml  | 28 ++++++++++++++--------------
+ 3 files changed, 17 insertions(+), 17 deletions(-)
+
+diff --git a/manifests/haproxy.yaml b/manifests/haproxy.yaml
+index ada52aa..24f4144 100644
+--- a/manifests/haproxy.yaml
++++ b/manifests/haproxy.yaml
+@@ -20,7 +20,7 @@ spec:
+       operator: "Exists"
+   containers:
+     - name: haproxy
+-      image: sles12/haproxy:__TAG__
++      image: sles12/haproxy:1.6.0
+       resources:
+         requests:
+           memory: 128Mi
+diff --git a/manifests/private.yaml b/manifests/private.yaml
+index 19e76ca..1ae9973 100644
+--- a/manifests/private.yaml
++++ b/manifests/private.yaml
+@@ -21,7 +21,7 @@ spec:
+   hostNetwork: False
+   initContainers:
+   - name: mariadb-secrets
+-    image: sles12/velum:__TAG__
++    image: sles12/velum:0.0
+     command: ["sh", "-c", "umask 377;
+                            if [ ! -f /infra-secrets/mariadb-root-password ]; then
+                              head -n 10 /dev/random | base64 | head -n 10 | tail -n 1 > /infra-secrets/mariadb-root-password;
+@@ -32,7 +32,7 @@ spec:
+       name: infra-secrets
+   containers:
+   - name: velum-mariadb
+-    image: sles12/mariadb:__TAG__
++    image: sles12/mariadb:10.0
+     env:
+     - name: MYSQL_DISABLE_REMOTE_ROOT
+       value: "true"
+diff --git a/manifests/public.yaml b/manifests/public.yaml
+index 0c4cab8..37d3051 100644
+--- a/manifests/public.yaml
++++ b/manifests/public.yaml
+@@ -21,7 +21,7 @@ spec:
+   hostNetwork: True
+   initContainers:
+   - name: mariadb-user-secrets
+-    image: sles12/mariadb:__TAG__
++    image: sles12/mariadb:10.0
+     command: ["/setup-mysql.sh"]
+     env:
+     - name: ENV
+@@ -35,7 +35,7 @@ spec:
+       name: setup-mysql
+       readOnly: True
+   - name: openldap-secrets
+-    image: sles12/velum:__TAG__
++    image: sles12/velum:0.0
+     command: ["sh", "-c", "umask 377;
+                            if [ ! -f /infra-secrets/openldap-password ]; then
+                              head -n 10 /dev/random | base64 | head -n 10 | tail -n 1 > /infra-secrets/openldap-password;
+@@ -45,7 +45,7 @@ spec:
+     - mountPath: /infra-secrets
+       name: infra-secrets
+   - name: saltapi-secrets
+-    image: sles12/velum:__TAG__
++    image: sles12/velum:0.0
+     command: ["sh", "-c", "umask 377;
+                            if [ ! -f /infra-secrets/saltapi-password ]; then
+                              head -n 10 /dev/random | base64 | head -n 10 | tail -n 1 > /infra-secrets/saltapi-password;
+@@ -55,7 +55,7 @@ spec:
+     - mountPath: /infra-secrets
+       name: infra-secrets
+   - name: salt-minion-key-generation
+-    image: sles12/salt-master:__TAG__
++    image: sles12/salt-master:2018.3.0
+     command: ["sh", "-c", "umask 377;
+                            mkdir /salt-master-pki/minions/;
+                            temp_dir=`mktemp -d`;
+@@ -87,7 +87,7 @@ spec:
+     - mountPath: /salt-admin-minion-pki
+       name: salt-admin-minion-pki
+   - name: salt-master-config
+-    image: sles12/velum:__TAG__
++    image: sles12/velum:0.0
+     command: ["sh", "-c", "umask 377;
+                            rmdir /salt-master-credentials/55-returner-credentials.conf;
+                            if ! grep mysql /salt-master-credentials/55-returner-credentials.conf; then
+@@ -103,7 +103,7 @@ spec:
+     - mountPath: /salt-master-credentials
+       name: salt-master-credentials
+   - name: velum-internal-api
+-    image: sles12/velum:__TAG__
++    image: sles12/velum:0.0
+     command: ["sh", "-c", "umask 377;
+                            if [ ! -f /infra-secrets/velum-internal-api-username ]; then
+                              head -n 10 /dev/random | base64 | head -n 10 | tail -n 1 > /infra-secrets/velum-internal-api-username;
+@@ -116,7 +116,7 @@ spec:
+     - mountPath: /infra-secrets
+       name: infra-secrets
+   - name: velum-dashboard-init
+-    image: sles12/velum:__TAG__
++    image: sles12/velum:0.0
+     env:
+     - name: RAILS_ENV
+       value: production
+@@ -149,7 +149,7 @@ spec:
+     args: ["bin/init"]
+   containers:
+   - name: salt-master
+-    image: sles12/salt-master:__TAG__
++    image: sles12/salt-master:2018.3.0
+     env:
+     - name: MYSQL_UNIX_PORT
+       value: /var/run/mysql/mysql.sock
+@@ -204,7 +204,7 @@ spec:
+       name: registry-config
+       readOnly: True
+   - name: salt-api
+-    image: sles12/salt-api:__TAG__
++    image: sles12/salt-api:2018.3.0
+     volumeMounts:
+     - mountPath: /etc/pki/salt-api.crt
+       name: salt-api-certificate
+@@ -223,7 +223,7 @@ spec:
+     - mountPath: /var/run/salt/master
+       name: salt-sock-dir
+   - name: salt-minion-ca
+-    image: sles12/salt-minion:__TAG__
++    image: sles12/salt-minion:2018.3.0
+     volumeMounts:
+     - mountPath: /etc/pki
+       name: salt-minion-ca-certificates
+@@ -246,7 +246,7 @@ spec:
+       name: registry-config
+       readOnly: True
+   - name: velum-dashboard
+-    image: sles12/velum:__TAG__
++    image: sles12/velum:0.0
+     env:
+     - name: RAILS_ENV
+       value: production
+@@ -330,7 +330,7 @@ spec:
+       readOnly: True
+     args: ["bin/run"]
+   - name: velum-api
+-    image: sles12/velum:__TAG__
++    image: sles12/velum:0.0
+     env:
+     - name: RAILS_ENV
+       value: production
+@@ -400,7 +400,7 @@ spec:
+       readOnly: True
+     args: ["bundle", "exec", "puma", "-C", "config/puma.rb"]
+   - name: openldap
+-    image: sles12/openldap:__TAG__
++    image: sles12/openldap:10.0
+     env:
+     - name: SLAPD_DOMAIN
+       value: "infra.caasp.local"
+@@ -428,7 +428,7 @@ spec:
+     - mountPath: /etc/openldap/slapd.d
+       name: openldap-config
+   - name: velum-event-processor
+-    image: sles12/velum:__TAG__
++    image: sles12/velum:0.0
+     env:
+     - name: WORKER_ID
+       value: worker1
+-- 
+2.16.4
+

--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -101,13 +101,16 @@ for file in manifests/*.yaml; do
   # fix image name
   sed -e "s|image:[ ]*sles12/\(.*\):|image: %{_base_image}/\1:|g" -i %{buildroot}/%{_datadir}/%{name}/\$file
 done
+# Install registry-configuration file
+install -d %{buildroot}/%{_datadir}/%{name}/config/registry
+install -D -m 0644 config/registry/registry-config.yaml %{buildroot}/%{_datadir}/%{name}/config/registry/registry-config.yaml
 install -D -m 0644 config/haproxy/haproxy.cfg %{buildroot}/etc/caasp/haproxy/haproxy.cfg
 install -D -m 0755 activate.sh %{buildroot}/%{_datadir}/%{name}/activate.sh
 # fix image name in activate
 sed -e "s|sles12/pause|%{_base_image}/pause|g" -i %{buildroot}/%{_datadir}/%{name}/activate.sh
 %if 0%{?suse_version} >= 1500
-# Adjust pause image version in activate
-sed -e "s|pause:1.0.0|pause:0.1|g" -i %{buildroot}/%{_datadir}/%{name}/activate.sh
+# adjust the use_registry variable
+sed -e "s|use_registry: false|use_registry: true|g" -i %{buildroot}/%{_datadir}/%{name}/config/registry/registry-config.yaml
 %endif
 install -D -m 0755 gen-certs.sh %{buildroot}/%{_datadir}/%{name}/gen-certs.sh
 for dir in salt/grains salt/minion.d-ca; do

--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -85,6 +85,7 @@ Requires:       %{_base_image}-caasp-dex-image >= 2.0.0
 Requires:       kubernetes-salt
 BuildArch:      noarch
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+Patch0:         0001-patch-in-version-numbers-for-images.patch
 
 %description
 Manifest file templates will instruct kubelet service to bring up salt
@@ -92,6 +93,15 @@ and velum containers on a controller node.
 
 %prep
 %setup -q -n ${NAME}-${SAFE_BRANCH}
+
+%if 0%{?suse_version} >= 1500
+# Without container-feeder we don't have the tag information available on the admin node anymore
+# That is why hotpatching the tags in won't work anymore (admin-node-setup.sh).
+# Once there is another way to get the correct tags for each image this patch should be removed.
+# Until then it has to be kept up-to-date with versions of images currently available in the
+# internal registry.
+%patch0 -p1
+%endif
 
 %build
 


### PR DESCRIPTION
This information will be modified and set during the build-time of the packages,
depending on the distribution it will be released to:

on SLE15 the information will contain the registry and set the use_registry to
true, on SLE12 the use_registry will remain false and use the images from
container-feeder.