### PR TITLE
[3.0] update to k8s 1.10.x (bsc#1114645)

### DIFF
--- a/admin-node-setup.sh
+++ b/admin-node-setup.sh
@@ -9,9 +9,6 @@ fi
 # Turn off current swaps if any
 /usr/sbin/swapoff -a
 
-# switch deprecated --config flag in kubelet
-sed -i -e "s/--config=/--pod-manifest-path=/g" /etc/kubernetes/kubelet
-
 # Update manifest files
 kube_dir=/etc/kubernetes/manifests
 manifest_dir=/usr/share/caasp-container-manifests/manifests


### PR DESCRIPTION
this requires the config flag to be set again, as it's now used
for a config manifest

Signed-off-by: Maximilian Meister <mmeister@suse.de>

https://bugzilla.suse.com/show_bug.cgi?id=1114645

this will fix the `3.0` CI in combination with https://github.com/kubic-project/salt/pull/680