### PR TITLE
[BSC#1111880] Change internal LDAP group name to prevent conflicts

### DIFF
--- a/manifests/public.yaml
+++ b/manifests/public.yaml
@@ -289,7 +289,7 @@ spec:
     - name: LDAP_BASE_DN
       value: dc=infra,dc=caasp,dc=local
     - name: LDAP_ADMIN_GROUP_DN
-      value: cn=Administrators,ou=Groups,dc=infra,dc=caasp,dc=local
+      value: cn=CaaSP-Administrators,ou=Groups,dc=infra,dc=caasp,dc=local
     - name: LDAP_TLS_METHOD
       value: start_tls
     - name: LDAP_MAIL_ATTRIBUTE


### PR DESCRIPTION
Change internal LDAP group name to prevent external auth conflicts

The internal LDAP group name for the Velum admin user was 'Administrators'. Once external auth is enabld to a companies LDAP server, this causes anyone in an Administrators group there also to gain permission to be a cluster admin.

Changing the name of the group to CaaSP-Administrators to prevent this conflict from occurring and it to be explicity obvious what the group is intended to administrate.