### PR TITLE
use /var/run/salt/master on host as socket dir

### DIFF
--- a/manifests/public.yaml
+++ b/manifests/public.yaml
@@ -541,7 +541,7 @@ spec:
       path: /usr/share/salt/kubernetes
   - name: salt-sock-dir
     hostPath:
-      path: /var/run/salt/master/sock-dir
+      path: /var/run/salt/master
   - name: salt-minion-ca-cache
     hostPath:
       path: /var/lib/misc/salt/cache/salt-minion-ca


### PR DESCRIPTION
Use /var/run/salt/master instead of /var/run/salt/master/sock-dir, as salt-cloud on the admin host expects the salt master socket files in that directory to send cloud events.

This is required to make https://github.com/kubic-project/velum/pull/700 work properly.