### PR TITLE
configure salt master socket dir on admin node

### DIFF
--- a/admin-node-setup.sh
+++ b/admin-node-setup.sh
@@ -133,3 +133,8 @@ Velum SHA256 fingerprint: $VELUM_CRT_FINGERPRINT_SHA256
 EOF
 # Call issue-generator to use the new issue.d snippet
 /usr/sbin/issue-generator
+
+# Configure path to salt master socket files
+# Required for salt-cloud to send cloud events through the master
+test -f /etc/salt/master || \
+  echo "sock_dir: /var/run/salt/master/sock-dir" > /etc/salt/master


### PR DESCRIPTION
Set salt master socket directory in /etc/salt/master on the admin node. This allows salt-cloud running on the admin node to send events through the master. Required for the node removal functionality to work properly in the cloud.

This PR supersedes https://github.com/kubic-project/caasp-container-manifests/pull/207.