### PR TITLE
adapt registry for now

### DIFF
--- a/config/registry/registry-config.yaml
+++ b/config/registry/registry-config.yaml
@@ -6,5 +6,5 @@
 #
 # namespace: denotes the root namespace under which all images can be found.
 use_registry: false
-host: registry.suse.de
-namespace: devel/casp/3.0/controllernode/images_container_base/sles12
+host: registry.suse.com
+namespace: sles12


### PR DESCRIPTION
at some point we can remove this functionality but for now
adapt the image path to the up-to-date registry.suse.com

Signed-off-by: Maximilian Meister <mmeister@suse.de>