### PR TITLE
point to registry.suse.com for the container images

### DIFF
--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -43,7 +43,7 @@ cat <<EOF > ${NAME}.spec
 
 %if 0%{?suse_version} == 1500 && !0%{?is_opensuse}
   # Use the sles12 images from the registry
-  %define _base_image registry.suse.de/devel/casp/3.0/controllernode/images_container_base/sles12
+  %define _base_image registry.suse.com/sles12
 %endif
 
 %if 0%{?is_opensuse} && 0%{?suse_version} > 1500


### PR DESCRIPTION
Signed-off-by: Maximilian Meister <mmeister@suse.de>


@jordimassaguerpla another thing that i discovered, which looks like a bug is https://github.com/kubic-project/caasp-container-manifests/blob/master/packaging/suse/make_spec.sh#L68-L82

even before the change of this PR, and expanded `%{_base_image}` would have looked like this in the requires:

```rpm
Requires:       registry.suse.de/devel/casp/3.0/controllernode/images_container_base/sles12-pause-image >= 2.0.0
```

is this correct?