### PR TITLE
Add cluster-internal CA to system trust store (was: user cert support)

### DIFF
--- a/admin-node-setup.sh
+++ b/admin-node-setup.sh
@@ -69,7 +69,7 @@ if [[ ! -f "/etc/caasp/haproxy/haproxy.cfg" && -f "/etc/haproxy/haproxy.cfg" ]];
 
 listen velum
         bind 0.0.0.0:80
-        bind 0.0.0.0:443 ssl crt /etc/pki/private/velum-bundle.pem ca-file /etc/pki/ca.crt
+        bind 0.0.0.0:443 ssl crt /etc/pki/private/velum-bundle.pem ca-file /var/lib/ca-certificates/ca-bundle.pem
         mode http
         acl path_autoyast path_reg ^/autoyast$
         option forwardfor
@@ -80,7 +80,7 @@ listen velum
         server velum unix@/var/run/puma/dashboard.sock
 
 listen velum-api
-        bind 127.0.0.1:443 ssl crt /etc/pki/private/velum-bundle.pem ca-file /etc/pki/ca.crt
+        bind 127.0.0.1:443 ssl crt /etc/pki/private/velum-bundle.pem ca-file /var/lib/ca-certificates/ca-bundle.pem
         mode http
         option forwardfor
         http-request set-header X-Forwarded-Proto https

--- a/config/haproxy/haproxy.cfg
+++ b/config/haproxy/haproxy.cfg
@@ -13,7 +13,7 @@ defaults
 
 listen velum
         bind 0.0.0.0:80
-        bind 0.0.0.0:443 ssl crt /etc/pki/private/velum-bundle.pem ca-file /var/lib/ca-certificates/ca-bundle.pem
+        bind 0.0.0.0:443 ssl crt /etc/pki/private/velum-bundle.pem ca-file /etc/pki/ca.crt
         mode http
         acl path_autoyast path_reg ^/autoyast$
         option forwardfor
@@ -25,7 +25,7 @@ listen velum
         errorfile 503 /etc/caasp/haproxy/errors/503.html.http
 
 listen velum-api
-        bind 127.0.0.1:444 ssl crt /etc/pki/private/velum-bundle.pem ca-file /var/lib/ca-certificates/ca-bundle.pem
+        bind 127.0.0.1:444 ssl crt /etc/pki/private/velum-bundle.pem ca-file /etc/pki/ca.crt
         mode http
         option forwardfor
         http-request set-header X-Forwarded-Proto https

--- a/config/haproxy/haproxy.cfg
+++ b/config/haproxy/haproxy.cfg
@@ -13,7 +13,7 @@ defaults
 
 listen velum
         bind 0.0.0.0:80
-        bind 0.0.0.0:443 ssl crt /etc/pki/private/velum-bundle.pem ca-file /etc/pki/ca.crt
+        bind 0.0.0.0:443 ssl crt /etc/pki/private/velum-bundle.pem ca-file /var/lib/ca-certificates/ca-bundle.pem
         mode http
         acl path_autoyast path_reg ^/autoyast$
         option forwardfor
@@ -25,7 +25,7 @@ listen velum
         errorfile 503 /etc/caasp/haproxy/errors/503.html.http
 
 listen velum-api
-        bind 127.0.0.1:444 ssl crt /etc/pki/private/velum-bundle.pem ca-file /etc/pki/ca.crt
+        bind 127.0.0.1:444 ssl crt /etc/pki/private/velum-bundle.pem ca-file /var/lib/ca-certificates/ca-bundle.pem
         mode http
         option forwardfor
         http-request set-header X-Forwarded-Proto https

--- a/gen-certs.sh
+++ b/gen-certs.sh
@@ -102,6 +102,11 @@ EOF
                 -out $DIR/ca.crt
 }
 
+trustca() {
+    ln -s $DIR/ca.crt /etc/pki/trust/anchors/
+    update-ca-certificates
+}
+
 gencert() {
     [ -f $PRIVATEDIR/$1.key ] && [ -f $DIR/$1.crt ] && return
 
@@ -170,6 +175,7 @@ all_hostnames=$(echo "$(hostname) $(hostname --fqdn) $(hostnamectl --transient) 
 
 set -e
 genca
+trustca
 gencert "velum" "Velum" "$all_hostnames" "$(ip_addresses)"
 gencert "salt-api" "salt-api.infra.caasp.local" "" "127.0.0.1"
 gencert "ldap" "OpenLDAP" "ldap.infra.caasp.local" "$(ip_addresses)"

--- a/manifests/haproxy.yaml
+++ b/manifests/haproxy.yaml
@@ -32,6 +32,9 @@ spec:
         - name: ca-certificate
           mountPath: /etc/pki/ca.crt
           readOnly: True
+        - mountPath: /var/lib/ca-certificates/
+          name: ca-bundle-dir
+          readOnly: True
         - name: kubernetes-proxy-bundle-certificate
           mountPath: /etc/pki/private/kube-apiserver-proxy-bundle.pem
           readOnly: True
@@ -52,6 +55,9 @@ spec:
       hostPath:
         path: /etc/pki/ca.crt
         type: FileOrCreate
+    - name: ca-bundle-dir
+      hostPath:
+        path: /var/lib/ca-certificates/
     - name: kubernetes-proxy-bundle-certificate
       hostPath:
         path: /etc/pki/private/kube-apiserver-proxy-bundle.pem

--- a/manifests/public.yaml
+++ b/manifests/public.yaml
@@ -308,6 +308,9 @@ spec:
     - mountPath: /var/lib/ca-certificates/ca-bundle.pem
       name: ca-bundle
       readOnly: True
+    - mountPath: /var/lib/ca-certificates/openssl
+      name: ca-dir
+      readOnly: True
     - mountPath: /var/run/mysql
       name: mariadb-unix-socket
     - mountPath: /var/run/puma
@@ -394,6 +397,9 @@ spec:
       readOnly: True
     - mountPath: /var/lib/ca-certificates/ca-bundle.pem
       name: ca-bundle
+      readOnly: True
+    - mountPath: /var/lib/ca-certificates/openssl
+      name: ca-dir
       readOnly: True
     - mountPath: /var/run/mysql
       name: mariadb-unix-socket
@@ -575,6 +581,9 @@ spec:
   - name: ca-bundle
     hostPath:
       path: /var/lib/ca-certificates/ca-bundle.pem
+  - name: ca-dir
+    hostPath:
+      path: /var/lib/ca-certificates/openssl
   - name: salt-minion-ca-grains
     hostPath:
       path: /usr/share/caasp-container-manifests/config/salt/grains/ca

--- a/manifests/public.yaml
+++ b/manifests/public.yaml
@@ -134,6 +134,9 @@ spec:
     - mountPath: /etc/pki/ca.crt
       name: ca-certificate
       readOnly: True
+    - mountPath: /var/lib/ca-certificates/
+      name: ca-bundle-dir
+      readOnly: True
     - mountPath: /var/run/mysql
       name: mariadb-unix-socket
     - mountPath: /var/lib/misc/velum-secrets
@@ -217,6 +220,9 @@ spec:
       readOnly: True
     - mountPath: /etc/pki/ca.crt
       name: ca-certificate
+      readOnly: True
+    - mountPath: /var/lib/ca-certificates/
+      name: ca-bundle-dir
       readOnly: True
     - mountPath: /etc/salt/master.d/50-api.conf
       name: salt-api-config-api-conf
@@ -496,6 +502,9 @@ spec:
     volumeMounts:
     - mountPath: /etc/pki/ca.crt
       name: ca-certificate
+      readOnly: True
+    - mountPath: /var/lib/ca-certificates/
+      name: ca-bundle-dir
       readOnly: True
     - mountPath: /var/run/mysql
       name: mariadb-unix-socket

--- a/manifests/public.yaml
+++ b/manifests/public.yaml
@@ -163,8 +163,8 @@ spec:
     - mountPath: /etc/pki/ca.crt
       name: ca-certificate
       readOnly: True
-    - mountPath: /var/lib/ca-certificates/ca-bundle.pem
-      name: ca-bundle
+    - mountPath: /var/lib/ca-certificates/
+      name: ca-bundle-dir
       readOnly: True
     - mountPath: /etc/salt/master.d/50-master.conf
       name: salt-master-config-master-conf
@@ -305,8 +305,8 @@ spec:
     - mountPath: /etc/pki/ca.crt
       name: ca-certificate
       readOnly: True
-    - mountPath: /var/lib/ca-certificates/ca-bundle.pem
-      name: ca-bundle
+    - mountPath: /var/lib/ca-certificates/
+      name: ca-bundle-dir
       readOnly: True
     - mountPath: /var/lib/ca-certificates/openssl
       name: ca-dir
@@ -395,8 +395,8 @@ spec:
     - mountPath: /etc/pki/ca.crt
       name: ca-certificate
       readOnly: True
-    - mountPath: /var/lib/ca-certificates/ca-bundle.pem
-      name: ca-bundle
+    - mountPath: /var/lib/ca-certificates/
+      name: ca-bundle-dir
       readOnly: True
     - mountPath: /var/lib/ca-certificates/openssl
       name: ca-dir
@@ -578,9 +578,9 @@ spec:
   - name: ca-certificate
     hostPath:
       path: /etc/pki/ca.crt
-  - name: ca-bundle
+  - name: ca-bundle-dir
     hostPath:
-      path: /var/lib/ca-certificates/ca-bundle.pem
+      path: /var/lib/ca-certificates/
   - name: ca-dir
     hostPath:
       path: /var/lib/ca-certificates/openssl

--- a/manifests/public.yaml
+++ b/manifests/public.yaml
@@ -163,6 +163,9 @@ spec:
     - mountPath: /etc/pki/ca.crt
       name: ca-certificate
       readOnly: True
+    - mountPath: /var/lib/ca-certificates/ca-bundle.pem
+      name: ca-bundle
+      readOnly: True
     - mountPath: /etc/salt/master.d/50-master.conf
       name: salt-master-config-master-conf
       readOnly: True
@@ -302,6 +305,9 @@ spec:
     - mountPath: /etc/pki/ca.crt
       name: ca-certificate
       readOnly: True
+    - mountPath: /var/lib/ca-certificates/ca-bundle.pem
+      name: ca-bundle
+      readOnly: True
     - mountPath: /var/run/mysql
       name: mariadb-unix-socket
     - mountPath: /var/run/puma
@@ -385,6 +391,9 @@ spec:
     volumeMounts:
     - mountPath: /etc/pki/ca.crt
       name: ca-certificate
+      readOnly: True
+    - mountPath: /var/lib/ca-certificates/ca-bundle.pem
+      name: ca-bundle
       readOnly: True
     - mountPath: /var/run/mysql
       name: mariadb-unix-socket
@@ -563,6 +572,9 @@ spec:
   - name: ca-certificate
     hostPath:
       path: /etc/pki/ca.crt
+  - name: ca-bundle
+    hostPath:
+      path: /var/lib/ca-certificates/ca-bundle.pem
   - name: salt-minion-ca-grains
     hostPath:
       path: /usr/share/caasp-container-manifests/config/salt/grains/ca


### PR DESCRIPTION
Update gen-certs script to add SUSE internal dynamically-generated CA into system trust store, and make that trust store available to haproxy + salt-master containers.  This is necessary to bring consistency to user-provided CA & certificate support.

This currently behaves ok, but PR is marked work-in-progress until the corresponding salt change (kubic-project/salt#721) is also ready to go (which will mean some changes)