### PR TITLE
Adjust the --pod-manifest-path flag to become the --config flag.

### DIFF
--- a/admin-node-setup.sh
+++ b/admin-node-setup.sh
@@ -53,6 +53,19 @@ if [ "$SERVER_ENABLED" == true ] || [ "$HEALTHZ_ENABLED" == true ]; then
     sed -i -e "s@^KUBELET_ARGS=\".*\"\$@KUBELET_ARGS=\"$KUBELET_ARGS\"@g" "$kubelet_config"
 fi
 
+# If the configuration file contains the statement:
+#
+# --pod-manifest-path=/etc/kubernetes/kubelet-config.yaml
+#
+# It was updated by the admin-setup.sh script incorrectly. In that case we
+# have to replace the `--pod-manifest-path` with `--config` again
+# Details: https://bugzilla.suse.com/show_bug.cgi?id=1124187
+# TODO: Remove with v4 release when no longer needed.
+if grep -q -- '--pod-manifest-path=/etc/kubernetes/kubelet-config.yaml' /etc/kubernetes/kubelet ; then
+    echo "Fixing pod-manifests-path to config in kubelet file"
+    sed -i 's/--pod-manifest-path/--config/g' /etc/kubernetes/kubelet
+fi
+
 tmp_dir=$(mktemp -d)
 
 cp $manifest_dir/*.yaml $tmp_dir


### PR DESCRIPTION
In a recent version of the script the --config flag was replaced with the
--pod-manifest-path flag that pointed to the kubelet-config.yaml file.

This can lead to a kubelet not working, so this will check for this specific
misconfiguration and adjust it back.

In newer cluster - as the statement was removed this should not happen anymore
and with version 4 we might be able to remove this workaround.