### PR TITLE
[WIP] Safer DB user creation

### DIFF
--- a/setup/mysql/setup-mysql.sh
+++ b/setup/mysql/setup-mysql.sh
@@ -8,6 +8,12 @@ done
 
 ENV=${ENV:-production}
 
+# only allow chars valid in MariaDB idenfiers (letters, numbers, underscore)
+shopt -s extglob
+ENV=${ENV//@([^[:word:]])}
+shopt -u extglob
+
+
 if [ ! -f /infra-secrets/mariadb-velum-password ]; then
     head -n 10 /dev/random | base64 | head -n 10 | tail -n 1 > /infra-secrets/mariadb-velum-password
 fi

--- a/setup/mysql/setup-mysql.sh
+++ b/setup/mysql/setup-mysql.sh
@@ -13,7 +13,6 @@ shopt -s extglob
 ENV=${ENV//@([^[:word:]])}
 shopt -u extglob
 
-
 if [ ! -f /infra-secrets/mariadb-velum-password ]; then
     head -n 10 /dev/random | base64 | head -n 10 | tail -n 1 > /infra-secrets/mariadb-velum-password
 fi
@@ -31,6 +30,11 @@ done
 
 velum_passwd=`cat /infra-secrets/mariadb-velum-password`
 salt_passwd=`cat /infra-secrets/mariadb-salt-password`
+
+if [[ -z "${velum_passwd}" || -z "${salt_passwd}" ]]; then
+    echo "Failed generating velum/salt passwords" >&2
+    exit 1
+fi
 
 mysql $mysql_flags -f <<EOF
   CREATE SCHEMA IF NOT EXISTS velum_$ENV;

--- a/setup/mysql/setup-mysql.sh
+++ b/setup/mysql/setup-mysql.sh
@@ -28,8 +28,10 @@ salt_passwd=`cat /infra-secrets/mariadb-salt-password`
 
 mysql $mysql_flags -f <<EOF
   CREATE SCHEMA IF NOT EXISTS velum_$ENV;
-  CREATE USER velum@localhost IDENTIFIED BY "$velum_passwd";
-  CREATE USER salt@localhost IDENTIFIED BY "$salt_passwd";
+  CREATE USER IF NOT EXISTS velum@localhost;
+  SET PASSWORD FOR          velum@localhost = PASSWORD( "$velum_passwd" );
+  CREATE USER IF NOT EXISTS salt@localhost;
+  SET PASSWORD FOR          salt@localhost = PASSWORD( "$salt_passwd" );
   GRANT ALL PRIVILEGES ON velum_$ENV.* TO velum@localhost;
   GRANT SELECT,INSERT,DELETE ON velum_$ENV.* TO salt@localhost;
   FLUSH PRIVILEGES;


### PR DESCRIPTION
Create DB user only if user doesn't already exist, and set password based on file contents.  This should help with backup/restore procedure, and generally makes more sense in that it won't generate error output in logs due to the user already existing.

Also added a couple of sanity / security checks while I was in there:
 * make sure the $ENV variable is safe to use in a query
 * make sure that the password files aren't empty.

Work-in-progress while doing some additional testing