### PR TITLE
Add missing kube-apiserver-haproxy-bundle.pem

### DIFF
--- a/manifests/haproxy.yaml
+++ b/manifests/haproxy.yaml
@@ -38,6 +38,9 @@ spec:
         - name: kubernetes-proxy-bundle-certificate
           mountPath: /etc/pki/private/kube-apiserver-proxy-bundle.pem
           readOnly: True
+        - name: kubernetes-apiserver-haproxy-client-bundle
+          mountPath: /etc/pki/private/kube-apiserver-haproxy-bundle.pem
+          readOnly: True
         - name: etc-hosts
           mountPath: /etc/hosts
         - name: velum-bundle-certificate
@@ -61,6 +64,10 @@ spec:
     - name: kubernetes-proxy-bundle-certificate
       hostPath:
         path: /etc/pki/private/kube-apiserver-proxy-bundle.pem
+        type: FileOrCreate
+    - name: kubernetes-apiserver-haproxy-client-bundle
+      hostPath:
+        path: /etc/pki/private/kube-apiserver-haproxy-bundle.pem
         type: FileOrCreate
     - name: etc-hosts
       hostPath:


### PR DESCRIPTION
I forgot to add this file mount to _this_ manifest, so it gets changed on reboot and breaks haproxy after salt changes the haproxy config during orchestration.  Merging this should fix the CI failure on kubic-project/salt#721

Probably should open an issue to have Salt maintain the /usr/share/caasp file when it updates the "real" file.  Or an issue to get rid of management of the same files by two processes...