### PR TITLE
[bsc#1121162] haproxy: block requests to /internal-api endpoint

### DIFF
--- a/admin-node-setup.sh
+++ b/admin-node-setup.sh
@@ -72,7 +72,9 @@ listen velum
         bind 0.0.0.0:443 ssl crt /etc/pki/private/velum-bundle.pem ca-file /var/lib/ca-certificates/ca-bundle.pem
         mode http
         acl path_autoyast path_reg ^/autoyast$
+        acl path_internal_api path_beg /internal-api
         option forwardfor
+        http-request deny if path_internal_api
         http-request set-header X-Forwarded-Proto https
         redirect scheme https code 302 if !{ ssl_fc } !path_autoyast
         default-server inter 10s fall 3

--- a/config/haproxy/haproxy.cfg
+++ b/config/haproxy/haproxy.cfg
@@ -16,7 +16,9 @@ listen velum
         bind 0.0.0.0:443 ssl crt /etc/pki/private/velum-bundle.pem ca-file /etc/pki/ca.crt
         mode http
         acl path_autoyast path_reg ^/autoyast$
+        acl path_internal_api path_beg /internal-api
         option forwardfor
+        http-request deny if path_internal_api
         http-request set-header X-Forwarded-Proto https
         redirect scheme https code 302 if !{ ssl_fc } !path_autoyast
         default-server inter 10s fall 3


### PR DESCRIPTION
Internal api endpoints exposes sensitive data and this cannot be
accessed via internet.

This internal api was developed inside velum project and haproxy was
allowing the request to that endpoint. Velum listens on 0.0.0.0 and
needs to block for that specific path.

With this patch we are blocking any request to anything that starts
with /internal-api.

Signed-off-by: Vítor Avelino <vavelino@suse.com>

bsc#1121162